### PR TITLE
Extra text functionality

### DIFF
--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
@@ -13,6 +13,7 @@ import org.squiddev.plethora.gameplay.modules.glasses.objects.Textable;
 
 import static dan200.computercraft.core.apis.ArgumentHelper.getInt;
 import static dan200.computercraft.core.apis.ArgumentHelper.getString;
+import static dan200.computercraft.core.apis.ArgumentHelper.getBoolean;
 import static org.squiddev.plethora.api.method.ArgumentHelper.assertBetween;
 import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
 
@@ -116,5 +117,20 @@ public class MethodsBasic {
 		assertBetween(contents.length(), 0, 512, "string length out of bounds (%s)");
 		object.setText(contents);
 		return MethodResult.empty();
+	}
+	
+	@BasicMethod.Inject(value = Textable.class, doc = "function(shadow:boolean):number -- Set the shadow for this object")
+	public static MethodResult setShadow(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
+		Textable object = context.safeBake().getTarget();
+
+		boolean shadow = getBoolean(args, 0);
+		object.setShadow(shadow);
+		return MethodResult.empty();
+	}
+	
+	@BasicMethod.Inject(value = Textable.class, doc = "function():boolean -- Get the shadow for this object")
+	public static MethodResult hasShadow(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
+		Textable object = context.safeBake().getTarget();
+		return MethodResult.result(object.hasShadow());
 	}
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
@@ -133,4 +133,19 @@ public class MethodsBasic {
 		Textable object = context.safeBake().getTarget();
 		return MethodResult.result(object.hasShadow());
 	}
+	
+	@BasicMethod.Inject(value = Textable.class, doc = "function():number -- Get the line height for this object.")
+	public static MethodResult getLineHeight(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
+		Textable object = context.safeBake().getTarget();
+		return MethodResult.result(object.getLineHeight());
+	}
+
+	@BasicMethod.Inject(value = Textable.class, doc = "function(scale:number) -- Set the line height for this object.")
+	public static MethodResult setLineHeight(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
+		Textable object = context.safeBake().getTarget();
+
+		short lineHeight = (short) getInt(args, 0);
+		object.setLineHeight(lineHeight);
+		return MethodResult.empty();
+	}
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
@@ -11,9 +11,7 @@ import org.squiddev.plethora.gameplay.modules.glasses.objects.Colourable;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.Scalable;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.Textable;
 
-import static dan200.computercraft.core.apis.ArgumentHelper.getInt;
-import static dan200.computercraft.core.apis.ArgumentHelper.getString;
-import static dan200.computercraft.core.apis.ArgumentHelper.getBoolean;
+import static dan200.computercraft.core.apis.ArgumentHelper.*;
 import static org.squiddev.plethora.api.method.ArgumentHelper.assertBetween;
 import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
 
@@ -118,7 +116,7 @@ public class MethodsBasic {
 		object.setText(contents);
 		return MethodResult.empty();
 	}
-	
+
 	@BasicMethod.Inject(value = Textable.class, doc = "function(shadow:boolean):number -- Set the shadow for this object.")
 	public static MethodResult setShadow(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
 		Textable object = context.safeBake().getTarget();
@@ -127,13 +125,13 @@ public class MethodsBasic {
 		object.setShadow(shadow);
 		return MethodResult.empty();
 	}
-	
+
 	@BasicMethod.Inject(value = Textable.class, doc = "function():boolean -- Get the shadow for this object.")
 	public static MethodResult hasShadow(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
 		Textable object = context.safeBake().getTarget();
 		return MethodResult.result(object.hasShadow());
 	}
-	
+
 	@BasicMethod.Inject(value = Textable.class, doc = "function():number -- Get the line height for this object.")
 	public static MethodResult getLineHeight(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
 		Textable object = context.safeBake().getTarget();

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsBasic.java
@@ -119,7 +119,7 @@ public class MethodsBasic {
 		return MethodResult.empty();
 	}
 	
-	@BasicMethod.Inject(value = Textable.class, doc = "function(shadow:boolean):number -- Set the shadow for this object")
+	@BasicMethod.Inject(value = Textable.class, doc = "function(shadow:boolean):number -- Set the shadow for this object.")
 	public static MethodResult setShadow(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
 		Textable object = context.safeBake().getTarget();
 
@@ -128,7 +128,7 @@ public class MethodsBasic {
 		return MethodResult.empty();
 	}
 	
-	@BasicMethod.Inject(value = Textable.class, doc = "function():boolean -- Get the shadow for this object")
+	@BasicMethod.Inject(value = Textable.class, doc = "function():boolean -- Get the shadow for this object.")
 	public static MethodResult hasShadow(IUnbakedContext<Textable> context, Object[] args) throws LuaException {
 		Textable object = context.safeBake().getTarget();
 		return MethodResult.result(object.hasShadow());

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/Textable.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/Textable.java
@@ -10,4 +10,7 @@ public interface Textable {
 	String getText();
 
 	void setText(@Nonnull String text);
+	
+	void setShadow(boolean dropShadow);
+	boolean hasShadow();
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/Textable.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/Textable.java
@@ -13,4 +13,7 @@ public interface Textable {
 	
 	void setShadow(boolean dropShadow);
 	boolean hasShadow();
+	
+	void setLineHeight(short height);
+	short getLineHeight();
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/Textable.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/Textable.java
@@ -10,10 +10,12 @@ public interface Textable {
 	String getText();
 
 	void setText(@Nonnull String text);
-	
+
 	void setShadow(boolean dropShadow);
+
 	boolean hasShadow();
-	
+
 	void setLineHeight(short height);
+
 	short getLineHeight();
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object2d/Text.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object2d/Text.java
@@ -22,6 +22,8 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 	private Point2D position = new Point2D();
 	private float size = 1;
 	private String text = "";
+	private boolean dropShadow = false;
+	private short lineHeight = 9;
 
 	// We use a two dimensional string array to indicate where tabs are.
 	// For example, "Hello\tworld\nFoo\tBar" would become {{"Hello", "world"}, {"Foo", "Bar"}}
@@ -30,7 +32,7 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 	// A tab is 4 spaces and one space is 4 pixels wide -> 1 tab is 4*4 (16) pixels wide. Used during rendering
 	private static final int TAB_WIDTH = 16;
 	private String[][] lines = EMPTY_LINES;
-	private boolean dropShadow = false;
+	
 
 	public Text(int id) {
 		super(id);
@@ -93,6 +95,19 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 	public boolean hasShadow() {
 		return dropShadow;
 	}
+	
+
+	@Override
+	public void setLineHeight(short lineHeight) {
+		if (this.lineHeight == lineHeight) return;
+		this.lineHeight = lineHeight;
+		setDirty();
+	}
+
+	@Override
+	public short getLineHeight() {
+		return lineHeight;
+	}
 
 	@Override
 	public void writeInital(ByteBuf buf) {
@@ -100,6 +115,7 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 		position.write(buf);
 		buf.writeFloat(size);
 		buf.writeBoolean(dropShadow);
+		buf.writeShort(lineHeight);
 		ByteBufUtils.writeUTF8String(buf, text);
 	}
 
@@ -109,6 +125,7 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 		position.read(buf);
 		size = buf.readFloat();
 		dropShadow = buf.readBoolean();
+		lineHeight = buf.readShort();
 		text = ByteBufUtils.readUTF8String(buf);
 		lines = splitText(text);
 	}
@@ -145,7 +162,7 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 			// Carriage return
 			x = 0;
 			// Set x to the next tab location
-			y += fontrenderer.FONT_HEIGHT;
+			y += this.lineHeight;
 		}
 
 		GlStateManager.popMatrix();

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object2d/Text.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object2d/Text.java
@@ -32,6 +32,7 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 	// A tab is 4 spaces and one space is 4 pixels wide -> 1 tab is 4*4 (16) pixels wide. Used during rendering
 	private static final int TAB_WIDTH = 16;
 	private String[][] lines = EMPTY_LINES;
+	private static final Pattern SPLIT_PATTERN = Pattern.compile("\r\n|\n|\r");
 	
 
 	public Text(int id) {
@@ -148,19 +149,17 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 		GlStateManager.translate(position.x, position.y, 0);
 		GlStateManager.scale(size, size, 1);
 
-		int x = 0;
 		int y = 0;
 		for (String[] fullLine : lines) {
+			int x = 0;
 			for (String tabSection : fullLine) {
 				// We use 0xRRGGBBAA, but the font renderer expects 0xAARRGGBB, so we rotate the bits
-				if (dropShadow)
-					x = fontrenderer.drawStringWithShadow(tabSection, x, y, Integer.rotateRight(colour, 8));
-				else
-					x = fontrenderer.drawString(tabSection, x, y, Integer.rotateRight(colour, 8));
+				x = dropShadow
+						  ? fontrenderer.drawStringWithShadow(tabSection, x, y, Integer.rotateRight(colour, 8))
+						  : fontrenderer.drawString(tabSection, x, y, Integer.rotateRight(colour, 8));
 				x = (int) Math.floor(x/TAB_WIDTH)*TAB_WIDTH+TAB_WIDTH;
 			}
 			// Carriage return
-			x = 0;
 			// Set x to the next tab location
 			y += this.lineHeight;
 		}
@@ -169,7 +168,7 @@ public class Text extends ColourableObject implements Positionable2D, Scalable, 
 	}
 
 	private String[][] splitText(String text) {
-		String[] lines = text.split("\n|\r");
+		String[] lines = SPLIT_PATTERN.split(text); // Split the text by \n\r, \n or \r
 		return Arrays.stream(lines).map(str -> str.split("\t")).toArray(String[][]::new);
 	}
 


### PR DESCRIPTION
This PR adds functionality for:

- The newline and carriage character `\n` and `\r`
- The tab character `\t`
- Allowing for the user to add a shadow to text objects
- Allowing for the user to modify the line height for text objects

4 new functions to text:
`setShadow(boolean shadow)` with documentation: `function(shadow:boolean):number -- Set the shadow for this object`
`hasShadow():boolean` with documentation: `function():boolean -- Get the shadow for this object`
`setLineHeight(short lineHeight)` with documentation: `function(scale:number) -- Set the line height for this object.`
`getLineHeight():number` with documentation: 'function():number -- Get the line height for this object.'

Newlines and carriage returns will instead of just displaying a character (LF and HT for line feed and horizontal tabulation), will both start a new line. This changes the visuals from this:
(Text used: `Foo\nbar\tHello world!`)
![before](https://shitty.download/KHe4.png)

To this:

![after](https://shitty.download/1NvT.png)

Applying a shadow effect to that would look like this: (using minecraft's already existing shadow rendering)

![shadow](https://shitty.download/bshb.png)

With a line height of `0`:

![zero](https://shitty.download/KQVZ.png)

And a line height of `18`: (Twice the default of 9)

![eighteen](https://shitty.download/zcM7.png)

Thank you!