### PR TITLE
Add 3D objects to terminal glasses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ dependencies {
 	compileOnly curseMod("storage-drawers", 2536306, "1.12.2-5.3.5")
 	compileOnly curseMod("chameleon", 2450900, "1.12-4.1.3")
 	compileOnly curseMod("blockcraftery", 2485336, "0.1.3")
+	compileOnly curseMod("elulib", 2533966, "0.1.12")
 
 	compileOnly('org.squiddev:ConfigGen:1.2.5') { exclude group: 'net.minecraftforge' }
 

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/BaseObject.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/BaseObject.java
@@ -93,7 +93,7 @@ public abstract class BaseObject {
 	}
 
 	/**
-	 * Draw this object in the 2D context.
+	 * Draw this object
 	 *
 	 * @param canvas The canvas context we are drawing within
 	 */

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/CanvasClient.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/CanvasClient.java
@@ -6,6 +6,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.squiddev.plethora.utils.DebugLogger;
 
 import static org.squiddev.plethora.gameplay.modules.glasses.CanvasHandler.ID_2D;
+import static org.squiddev.plethora.gameplay.modules.glasses.CanvasHandler.ID_3D;
 
 public class CanvasClient {
 	public final int id;
@@ -16,6 +17,7 @@ public class CanvasClient {
 	public CanvasClient(int id) {
 		this.id = id;
 		this.childrenOf.put(ID_2D, new IntAVLTreeSet());
+		this.childrenOf.put(ID_3D, new IntAVLTreeSet());
 	}
 
 	public void updateObject(BaseObject object) {

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/CanvasHandler.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/CanvasHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
@@ -26,6 +27,7 @@ import static org.squiddev.plethora.gameplay.neural.ItemComputerHandler.MODULE_D
 
 public class CanvasHandler {
 	public static final int ID_2D = 0;
+	public static final int ID_3D = 1;
 
 	public static final int WIDTH = 512;
 	public static final int HEIGHT = 512 / 16 * 9;
@@ -145,5 +147,16 @@ public class CanvasHandler {
 		GlStateManager.enableCull();
 
 		GlStateManager.popMatrix();
+	}
+
+	@SubscribeEvent
+	@SideOnly(Side.CLIENT)
+	public void onWorldRender(RenderWorldLastEvent event) {
+		CanvasClient canvas = getCanvas();
+		if (canvas == null) return;
+
+		synchronized (canvas) {
+			canvas.drawChildren(canvas.getChildren(ID_3D).iterator());
+		}
 	}
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/CanvasServer.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/CanvasServer.java
@@ -14,9 +14,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.squiddev.plethora.gameplay.modules.glasses.CanvasHandler.ID_2D;
+import static org.squiddev.plethora.gameplay.modules.glasses.CanvasHandler.ID_3D;
 
 public final class CanvasServer extends ConstantReference<CanvasServer> implements IAttachable {
-
 	private final int canvasId;
 	private final IModuleAccess access;
 	private final EntityPlayerMP player;
@@ -26,9 +26,10 @@ public final class CanvasServer extends ConstantReference<CanvasServer> implemen
 
 	private final IntSet removed = new IntOpenHashSet();
 
-	private AtomicInteger lastId = new AtomicInteger(ID_2D);
+	private AtomicInteger lastId = new AtomicInteger(ID_3D);
 
 	private final ObjectGroup.Group2D group2D = () -> ID_2D;
+	private final ObjectGroup.Origin3D origin3D = () -> ID_3D;
 
 	public CanvasServer(@Nonnull IModuleAccess access, @Nonnull EntityPlayerMP player) {
 		this.canvasId = CanvasHandler.nextId();
@@ -36,6 +37,7 @@ public final class CanvasServer extends ConstantReference<CanvasServer> implemen
 		this.player = player;
 
 		this.childrenOf.put(ID_2D, new IntOpenHashSet());
+		this.childrenOf.put(ID_3D, new IntOpenHashSet());
 	}
 
 	@Override
@@ -58,6 +60,10 @@ public final class CanvasServer extends ConstantReference<CanvasServer> implemen
 
 	public ObjectGroup.Group2D canvas2d() {
 		return group2D;
+	}
+
+	public ObjectGroup.Origin3D canvas3d() {
+		return origin3D;
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/ObjectGroup.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/ObjectGroup.java
@@ -14,4 +14,16 @@ public interface ObjectGroup {
 	 */
 	interface Group2D extends ObjectGroup {
 	}
+
+	/**
+	 * A group for 3D objects
+	 */
+	interface Group3D extends ObjectGroup {
+	}
+
+	/**
+	 * The "origin" for all 3D objects
+	 */
+	interface Origin3D extends ObjectGroup {
+	}
 }

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/ArgumentPointHelper.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/ArgumentPointHelper.java
@@ -1,6 +1,7 @@
 package org.squiddev.plethora.gameplay.modules.glasses.methods;
 
 import dan200.computercraft.api.lua.LuaException;
+import net.minecraft.util.math.Vec3d;
 import org.squiddev.plethora.utils.Vec2d;
 
 import javax.annotation.Nonnull;
@@ -32,6 +33,37 @@ public class ArgumentPointHelper {
 		}
 
 		return new Vec2d(((Number) xObj).doubleValue(), ((Number) yObj).doubleValue());
+	}
+
+	public static Vec3d getPoint3D(@Nonnull Object[] args, int index) throws LuaException {
+		return getPoint3D(getTable(args, index));
+	}
+
+	public static Vec3d getPoint3D(Map<?, ?> point) throws LuaException {
+		Object xObj, yObj, zObj;
+		if (point.containsKey("x")) {
+			xObj = point.get("x");
+			yObj = point.get("y");
+			zObj = point.get("z");
+
+			if (!(xObj instanceof Number)) throw badKey(xObj, "x", "number");
+			if (!(yObj instanceof Number)) throw badKey(yObj, "y", "number");
+			if (!(zObj instanceof Number)) throw badKey(yObj, "z", "number");
+		} else {
+			xObj = point.get(1.0);
+			yObj = point.get(2.0);
+			zObj = point.get(3.0);
+
+			if (!(xObj instanceof Number)) throw badKey(xObj, "1", "number");
+			if (!(yObj instanceof Number)) throw badKey(yObj, "2", "number");
+			if (!(zObj instanceof Number)) throw badKey(yObj, "3", "number");
+		}
+
+		return new Vec3d(
+			((Number) xObj).doubleValue(),
+			((Number) yObj).doubleValue(),
+			((Number) zObj).doubleValue()
+		);
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas.java
@@ -23,6 +23,16 @@ public class MethodsCanvas {
 		return MethodResult.result(baked.makeChildId(server.canvas2d()).getObject());
 	}
 
+	@SubtargetedModuleMethod.Inject(
+		target = CanvasServer.class, module = PlethoraModules.GLASSES_S,
+		doc = "function():table -- Get the 3D canvas for these glasses."
+	)
+	public static MethodResult canvas3d(IUnbakedContext<IModuleContainer> context, Object[] args) throws LuaException {
+		IContext<IModuleContainer> baked = context.safeBake();
+		CanvasServer server = baked.getContext(PlethoraModules.GLASSES_S, CanvasServer.class);
+		return MethodResult.result(baked.makeChildId(server.canvas3d()).getObject());
+	}
+
 	@BasicMethod.Inject(value = ObjectGroup.class, doc = "function() -- Remove all objects.")
 	public static MethodResult clear(IUnbakedContext<ObjectGroup> context, Object[] args) throws LuaException {
 		IContext<ObjectGroup> baked = context.safeBake();

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
@@ -1,0 +1,96 @@
+package org.squiddev.plethora.gameplay.modules.glasses.methods;
+
+import dan200.computercraft.api.lua.LuaException;
+import net.minecraft.util.math.Vec3d;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.method.*;
+import org.squiddev.plethora.gameplay.modules.glasses.CanvasServer;
+import org.squiddev.plethora.gameplay.modules.glasses.ObjectGroup.Group3D;
+import org.squiddev.plethora.gameplay.modules.glasses.ObjectGroup.Origin3D;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Box;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Line3D;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.ObjectRoot3D;
+
+import static dan200.computercraft.core.apis.ArgumentHelper.optBoolean;
+import static dan200.computercraft.core.apis.ArgumentHelper.optInt;
+import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
+import static org.squiddev.plethora.api.method.ArgumentHelper.optFloat;
+import static org.squiddev.plethora.gameplay.modules.glasses.methods.ArgumentPointHelper.getPoint3D;
+import static org.squiddev.plethora.gameplay.modules.glasses.objects.Colourable.DEFAULT_COLOUR;
+
+public class MethodsCanvas3D {
+	@BasicMethod.Inject(value = Origin3D.class, doc = "function():table -- Create a new 3D canvas centred on the current position.")
+	public static MethodResult create(IUnbakedContext<Origin3D> context, Object[] args) throws LuaException {
+		IContext<Origin3D> baked = context.safeBake();
+		Origin3D group = baked.getTarget();
+		CanvasServer canvas = baked.getContext(CanvasServer.class);
+
+		IWorldLocation location = baked.getContext(ContextKeys.ORIGIN, IWorldLocation.class);
+		if (location == null) throw new LuaException("Cannot determine a location");
+
+		ObjectRoot3D root = new ObjectRoot3D(canvas.newObjectId(), group.id());
+		root.recentre(location);
+
+		canvas.add(root);
+		return MethodResult.result(baked.makeChild(root, root.reference(canvas)).getObject());
+	}
+
+	@BasicMethod.Inject(value = Group3D.class, doc = "function(x:number, y:number, z:number[, width: number, height:number, depth:number][, colour:number[, depth:boolean]]):table -- Create a new box.")
+	public static MethodResult addBox(IUnbakedContext<Group3D> context, Object[] args) throws LuaException {
+		double x = getFloat(args, 0);
+		double y = getFloat(args, 1);
+		double z = getFloat(args, 2);
+
+		int colour;
+		double width, height, depth;
+		boolean depthTesting;
+		if (args.length > 3) {
+			width = getFloat(args, 3);
+			height = getFloat(args, 4);
+			depth = getFloat(args, 5);
+			colour = optInt(args, 6, DEFAULT_COLOUR);
+			depthTesting = optBoolean(args, 7, true);
+		} else {
+			width = 1;
+			height = 1;
+			depth = 1;
+			colour = optInt(args, 3, DEFAULT_COLOUR);
+			depthTesting = optBoolean(args, 4, true);
+		}
+
+		IContext<Group3D> baked = context.safeBake();
+		Group3D group = baked.getTarget();
+		CanvasServer canvas = baked.getContext(CanvasServer.class);
+
+		Box box = new Box(canvas.newObjectId(), group.id());
+		box.setPosition(new Vec3d(x, y, z));
+		box.setSize(width, height, depth);
+		box.setColour(colour);
+		box.setDepthTestingEnabled(depthTesting);
+
+		canvas.add(box);
+		return MethodResult.result(baked.makeChild(box, box.reference(canvas)).getObject());
+	}
+
+	@BasicMethod.Inject(value = Group3D.class, doc = "function(start:table, end:table[, color:number][, thickness:numbner] -- Creates a new 3d line")
+	public static MethodResult addLine3D(IUnbakedContext<Group3D> context, Object[] args) throws LuaException {
+		Vec3d start = getPoint3D(args, 0);
+		Vec3d end = getPoint3D(args, 1);
+		int colour = optInt(args, 2, DEFAULT_COLOUR);
+		float thickness = optFloat(args, 3, 1);
+
+		IContext<Group3D> baked = context.safeBake();
+		Group3D group = baked.getTarget();
+		CanvasServer canvas = baked.getContext(CanvasServer.class);
+
+		Line3D line = new Line3D(canvas.newObjectId(), group.id());
+		line.setVertex(0, start);
+		line.setVertex(1, end);
+		line.setColour(colour);
+		line.setScale(thickness);
+
+		canvas.add(line);
+
+		return MethodResult.result(baked.makeChild(line, line.reference(canvas)).getObject());
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/ObjectRegistry.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/ObjectRegistry.java
@@ -4,6 +4,9 @@ import io.netty.buffer.ByteBuf;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import org.squiddev.plethora.gameplay.modules.glasses.BaseObject;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.object2d.*;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Box;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Line3D;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.ObjectRoot3D;
 
 public final class ObjectRegistry {
 	public static final byte RECTANGLE_2D = 0;
@@ -16,6 +19,10 @@ public final class ObjectRegistry {
 	public static final byte ITEM_2D = 7;
 	public static final byte GROUP_2D = 8;
 
+	public static final byte ORIGIN_3D = 9;
+	public static final byte BOX_3D = 10;
+	public static final byte LINE_3D = 11;
+
 	private static final BaseObject.Factory[] FACTORIES = {
 		Rectangle::new,
 		Line::new,
@@ -25,7 +32,11 @@ public final class ObjectRegistry {
 		Polygon::new,
 		LineLoop::new,
 		Item2D::new,
-		ObjectGroup2D::new
+		ObjectGroup2D::new,
+
+		ObjectRoot3D::new,
+		Box::new,
+		Line3D::new,
 	};
 
 	private ObjectRegistry() {

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Box.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Box.java
@@ -1,0 +1,116 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.util.math.Vec3d;
+import org.lwjgl.opengl.GL11;
+import org.squiddev.plethora.gameplay.modules.glasses.CanvasClient;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ColourableObject;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectRegistry;
+import org.squiddev.plethora.utils.ByteBufUtils;
+import org.squiddev.plethora.utils.GeometryMasks;
+import org.squiddev.plethora.utils.ShapeTesellator;
+
+public class Box extends ColourableObject implements Positionable3D, Sizeable3D, DepthTestable {
+	private Vec3d position;
+	private double width;
+	private double height;
+	private double depth;
+
+	private boolean depthTest;
+
+	public Box(int id, int parent) {
+		super(id, parent, ObjectRegistry.BOX_3D);
+	}
+
+	@Override
+	public void setDepthTestingEnabled(boolean testingEnabled) {
+		if (this.depthTest != testingEnabled) {
+			this.depthTest = testingEnabled;
+			setDirty();
+		}
+	}
+
+	@Override
+	public boolean isDepthTestingEnabled() {
+		return depthTest;
+	}
+
+	@Override
+	public Vec3d getPosition() {
+		return position;
+	}
+
+	@Override
+	public void setPosition(Vec3d position) {
+		if (!Objects.equal(this.position, position)) {
+			this.position = position;
+			setDirty();
+		}
+	}
+
+	@Override
+	public double getWidth() {
+		return width;
+	}
+
+	@Override
+	public double getHeight() {
+		return height;
+	}
+
+	@Override
+	public double getDepth() {
+		return depth;
+	}
+
+	@Override
+	public void setSize(double width, double height, double depth) {
+		if (this.width != width || this.height != height || this.depth != depth) {
+			this.width = width;
+			this.height = height;
+			this.depth = depth;
+			setDirty();
+		}
+	}
+
+	@Override
+	public void readInitial(ByteBuf buf) {
+		super.readInitial(buf);
+
+		position = ByteBufUtils.readVec3d(buf);
+		width = buf.readDouble();
+		height = buf.readDouble();
+		depth = buf.readDouble();
+		depthTest = buf.readBoolean();
+	}
+
+	@Override
+	public void writeInitial(ByteBuf buf) {
+		super.writeInitial(buf);
+
+		ByteBufUtils.writeVec3d(buf, position);
+		buf.writeDouble(width);
+		buf.writeDouble(height);
+		buf.writeDouble(depth);
+		buf.writeBoolean(depthTest);
+	}
+
+	@Override
+	public void draw(CanvasClient canvas) {
+		if (depthTest) GL11.glEnable(GL11.GL_DEPTH_TEST);
+
+		// Add a stupidly small number to the coords to prevent colliding faces looking terrible
+		double offset = 0.003D;
+		ShapeTesellator.prepare(GL11.GL_QUADS);
+		ShapeTesellator.drawBox(
+			position.x + offset, position.y + offset, position.z + offset,
+			width - offset * 2, height - offset * 2, depth - offset * 2,
+			Integer.rotateRight(getColour(), 8),
+			GeometryMasks.Quad.ALL
+		);
+		ShapeTesellator.release();
+
+		if (depthTest) GL11.glDisable(GL11.GL_DEPTH_TEST);
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/DepthTestable.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/DepthTestable.java
@@ -1,0 +1,17 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import dan200.computercraft.api.lua.LuaException;
+import org.squiddev.plethora.api.method.BasicMethod;
+import org.squiddev.plethora.api.method.IUnbakedContext;
+import org.squiddev.plethora.api.method.MethodResult;
+
+public interface DepthTestable {
+	boolean isDepthTestingEnabled();
+
+	void setDepthTestingEnabled(boolean testingEnabled);
+
+	@BasicMethod.Inject(value = DepthTestable.class, doc = "function():boolean -- Get whether or not depth testing is enabled for this object")
+	static MethodResult hasDepthTesting(IUnbakedContext<DepthTestable> context, Object[] args) throws LuaException {
+		return MethodResult.result(context.safeBake().getTarget().isDepthTestingEnabled());
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
@@ -1,0 +1,103 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.util.math.Vec3d;
+import org.lwjgl.opengl.GL11;
+import org.squiddev.plethora.gameplay.modules.glasses.CanvasClient;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ColourableObject;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectRegistry;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.Scalable;
+import org.squiddev.plethora.utils.ByteBufUtils;
+import org.squiddev.plethora.utils.ShapeTesellator;
+
+import static org.lwjgl.opengl.GL11.GL_LINES;
+
+/**
+ * Created by 086 on 29/04/2018.
+ *
+ * @see org.squiddev.plethora.gameplay.modules.glasses.objects.object2d.Line
+ */
+public class Line3D extends ColourableObject implements MultiPoint3D, Scalable {
+	private Vec3d start;
+	private Vec3d end;
+	private float thickness = 1;
+
+	public Line3D(int id, int parent) {
+		super(id, parent, ObjectRegistry.LINE_3D);
+	}
+
+	@Override
+	public float getScale() {
+		return thickness;
+	}
+
+	@Override
+	public void setScale(float scale) {
+		if (this.thickness != scale) {
+			this.thickness = scale;
+			setDirty();
+		}
+	}
+
+	@Override
+	public Vec3d getPoint(int idx) {
+		return idx == 0 ? start : end;
+	}
+
+	@Override
+	public void setVertex(int idx, Vec3d point) {
+		if (idx == 0) {
+			if (!point.equals(start)) {
+				start = point;
+				setDirty();
+			}
+		} else {
+			if (!point.equals(end)) {
+				end = point;
+				setDirty();
+			}
+		}
+	}
+
+	@Override
+	public int getVertices() {
+		return 2;
+	}
+
+	@Override
+	public void writeInitial(ByteBuf buf) {
+		super.writeInitial(buf);
+		start = ByteBufUtils.readVec3d(buf);
+		end = ByteBufUtils.readVec3d(buf);
+		buf.writeFloat(thickness);
+	}
+
+	@Override
+	public void readInitial(ByteBuf buf) {
+		super.readInitial(buf);
+		ByteBufUtils.writeVec3d(buf, start);
+		ByteBufUtils.writeVec3d(buf, end);
+		thickness = buf.readFloat();
+	}
+
+	@Override
+	public void draw(CanvasClient canvas) {
+		int rgba = getColour();
+		final int r = (rgba >>> 24) & 0xFF;
+		final int g = (rgba >>> 16) & 0xFF;
+		final int b = (rgba >>> 8) & 0xFF;
+		final int a = rgba & 0xFF;
+
+		GL11.glLineWidth(thickness);
+
+		BufferBuilder bufferBuilder = ShapeTesellator.getBufferBuilder();
+		ShapeTesellator.prepare(GL_LINES);
+		bufferBuilder.pos(start.x, start.y, start.z).color(r, g, b, a).endVertex();
+		bufferBuilder.pos(end.x, end.y, end.z).color(r, g, b, a).endVertex();
+		ShapeTesellator.release();
+
+		GL11.glLineWidth(1);
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/MultiPoint3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/MultiPoint3D.java
@@ -1,0 +1,44 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import dan200.computercraft.api.lua.LuaException;
+import net.minecraft.util.math.Vec3d;
+import org.squiddev.plethora.api.method.BasicMethod;
+import org.squiddev.plethora.api.method.IUnbakedContext;
+import org.squiddev.plethora.api.method.MethodResult;
+
+import static dan200.computercraft.core.apis.ArgumentHelper.getInt;
+import static org.squiddev.plethora.api.method.ArgumentHelper.assertBetween;
+import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
+
+/**
+ * A polygon for which you can set multiple points.
+ */
+public interface MultiPoint3D {
+	Vec3d getPoint(int idx);
+
+	void setVertex(int idx, Vec3d point);
+
+	int getVertices();
+
+	@BasicMethod.Inject(value = MultiPoint3D.class, doc = "function(idx:int):number, number, number -- Get the specified vertex of this object.")
+	static MethodResult getPoint(IUnbakedContext<MultiPoint3D> context, Object[] args) throws LuaException {
+		MultiPoint3D object = context.safeBake().getTarget();
+
+		int idx = getInt(args, 0);
+		assertBetween(idx, 1, object.getVertices(), "Index out of range (%s)");
+
+		Vec3d point = object.getPoint(idx - 1);
+		return MethodResult.result(point.x, point.y, point.z);
+	}
+
+	@BasicMethod.Inject(value = MultiPoint3D.class, doc = "function(idx:int, x:number, y:number, z:number) -- Set the specified vertex of this object.")
+	static MethodResult setPoint(IUnbakedContext<MultiPoint3D> context, Object[] args) throws LuaException {
+		MultiPoint3D object = context.safeBake().getTarget();
+
+		int idx = getInt(args, 0);
+		assertBetween(idx, 1, object.getVertices(), "Index out of range (%s)");
+
+		object.setVertex(idx - 1, new Vec3d(getFloat(args, 1), getFloat(args, 2), getFloat(args, 3)));
+		return MethodResult.empty();
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/ObjectRoot3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/ObjectRoot3D.java
@@ -1,0 +1,84 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import dan200.computercraft.api.lua.LuaException;
+import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.util.math.Vec3d;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.method.*;
+import org.squiddev.plethora.gameplay.modules.glasses.BaseObject;
+import org.squiddev.plethora.gameplay.modules.glasses.CanvasClient;
+import org.squiddev.plethora.gameplay.modules.glasses.ObjectGroup;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectRegistry;
+import org.squiddev.plethora.utils.ByteBufUtils;
+
+public class ObjectRoot3D extends BaseObject implements ObjectGroup.Group3D {
+	private Vec3d origin;
+	private int dimension;
+
+	public ObjectRoot3D(int id, int parent) {
+		super(id, parent, ObjectRegistry.ORIGIN_3D);
+	}
+
+	public void recentre(IWorldLocation location) {
+		Vec3d origin = location.getLoc();
+		int dimension = location.getWorld().provider.getDimension();
+
+		if (!origin.equals(this.origin) || dimension != this.dimension) {
+			this.origin = origin;
+			this.dimension = dimension;
+			setDirty();
+		}
+	}
+
+	@Override
+	public void readInitial(ByteBuf buf) {
+		origin = ByteBufUtils.readVec3d(buf);
+		dimension = buf.readInt();
+	}
+
+	@Override
+	public void writeInitial(ByteBuf buf) {
+		ByteBufUtils.writeVec3d(buf, origin);
+		buf.writeInt(dimension);
+	}
+
+	@Override
+	public void draw(CanvasClient canvas) {
+		IntSet children = canvas.getChildren(id());
+		if (children == null) return;
+
+		Minecraft minecraft = Minecraft.getMinecraft();
+		RenderManager renderManager = minecraft.getRenderManager();
+
+		if (renderManager.renderViewEntity == null || renderManager.renderViewEntity.world.provider.getDimension() != dimension) {
+			return;
+		}
+
+		// TODO: Determine a better way of handling this.
+		double distance = renderManager.options.renderDistanceChunks * 16;
+		if (origin.squareDistanceTo(renderManager.viewerPosX, renderManager.viewerPosY, renderManager.viewerPosZ) > distance * distance) {
+			return;
+		}
+
+		GlStateManager.pushMatrix();
+		GlStateManager.translate(-renderManager.viewerPosX + origin.x, -renderManager.viewerPosY + origin.y, -renderManager.viewerPosZ + origin.z);
+
+		canvas.drawChildren(children.iterator());
+
+		GlStateManager.popMatrix();
+	}
+
+	@BasicMethod.Inject(value = ObjectRoot3D.class, doc = "function():table -- Recenter this canvas to the current position.")
+	public static MethodResult recenter(IUnbakedContext<ObjectRoot3D> context, Object[] args) throws LuaException {
+		IContext<ObjectRoot3D> baked = context.safeBake();
+		IWorldLocation location = baked.getContext(ContextKeys.ORIGIN, IWorldLocation.class);
+		if (location == null) throw new LuaException("Cannot determine a location");
+
+		baked.getTarget().recentre(location);
+		return MethodResult.empty();
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Positionable3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Positionable3D.java
@@ -1,0 +1,29 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import dan200.computercraft.api.lua.LuaException;
+import net.minecraft.util.math.Vec3d;
+import org.squiddev.plethora.api.method.BasicMethod;
+import org.squiddev.plethora.api.method.IUnbakedContext;
+import org.squiddev.plethora.api.method.MethodResult;
+
+import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
+
+public interface Positionable3D {
+	Vec3d getPosition();
+
+	void setPosition(Vec3d position);
+
+	@BasicMethod.Inject(value = Positionable3D.class, doc = "function():number, number, number -- Get the position for this object.")
+	static MethodResult getPosition(IUnbakedContext<Positionable3D> context, Object[] args) throws LuaException {
+		Positionable3D object = context.safeBake().getTarget();
+		Vec3d pos = object.getPosition();
+		return MethodResult.result(pos.x, pos.y, pos.z);
+	}
+
+	@BasicMethod.Inject(value = Positionable3D.class, doc = "function(x:number, y:number, z:number) -- Set the position for this object.")
+	static MethodResult setPosition(IUnbakedContext<Positionable3D> context, Object[] args) throws LuaException {
+		Positionable3D object = context.safeBake().getTarget();
+		object.setPosition(new Vec3d(getFloat(args, 0), getFloat(args, 1), getFloat(args, 2)));
+		return MethodResult.empty();
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Sizeable3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Sizeable3D.java
@@ -1,0 +1,11 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+public interface Sizeable3D {
+	double getWidth();
+
+	double getHeight();
+
+	double getDepth();
+
+	void setSize(double width, double height, double depth);
+}

--- a/src/main/java/org/squiddev/plethora/utils/GeometryMasks.java
+++ b/src/main/java/org/squiddev/plethora/utils/GeometryMasks.java
@@ -1,0 +1,44 @@
+package org.squiddev.plethora.utils;
+
+import net.minecraft.util.EnumFacing;
+
+import java.util.HashMap;
+
+public final class GeometryMasks {
+
+	public static final HashMap<EnumFacing, Integer> FACEMAP = new HashMap<>();
+	static {
+		FACEMAP.put(EnumFacing.DOWN, Quad.DOWN);
+		FACEMAP.put(EnumFacing.WEST, Quad.WEST);
+		FACEMAP.put(EnumFacing.NORTH, Quad.NORTH);
+		FACEMAP.put(EnumFacing.SOUTH, Quad.SOUTH);
+		FACEMAP.put(EnumFacing.EAST, Quad.EAST);
+		FACEMAP.put(EnumFacing.UP, Quad.UP);
+	}
+
+	public static final class Quad {
+		public static final int DOWN = 0x01;
+		public static final int UP = 0x02;
+		public static final int NORTH = 0x04;
+		public static final int SOUTH = 0x08;
+		public static final int WEST = 0x10;
+		public static final int EAST = 0x20;
+		public static final int ALL = DOWN | UP | NORTH | SOUTH | WEST | EAST;
+	}
+
+	public static final class Line {
+		public static final int DOWN_WEST = 0x11;
+		public static final int UP_WEST = 0x12;
+		public static final int DOWN_EAST = 0x21;
+		public static final int UP_EAST = 0x22;
+		public static final int DOWN_NORTH = 0x05;
+		public static final int UP_NORTH = 0x06;
+		public static final int DOWN_SOUTH = 0x09;
+		public static final int UP_SOUTH = 0x0A;
+		public static final int NORTH_WEST = 0x14;
+		public static final int NORTH_EAST = 0x24;
+		public static final int SOUTH_WEST = 0x18;
+		public static final int SOUTH_EAST = 0x28;
+		public static final int ALL = DOWN_WEST | UP_WEST | DOWN_EAST | UP_EAST | DOWN_NORTH | UP_NORTH | DOWN_SOUTH | UP_SOUTH | NORTH_WEST | NORTH_EAST | SOUTH_WEST | SOUTH_EAST;
+	}
+}

--- a/src/main/java/org/squiddev/plethora/utils/ShapeTesellator.java
+++ b/src/main/java/org/squiddev/plethora/utils/ShapeTesellator.java
@@ -1,0 +1,194 @@
+package org.squiddev.plethora.utils;
+
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.util.math.BlockPos;
+
+import static org.lwjgl.opengl.GL11.*;
+
+public class ShapeTesellator extends Tessellator {
+
+	public static ShapeTesellator INSTANCE = new ShapeTesellator();
+
+	public ShapeTesellator() {
+		super(0x200000);
+	}
+
+	public static void prepare(int mode) {
+		prepareGL();
+		begin(mode);
+	}
+
+	public static void prepareGL() {
+//        GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+		GlStateManager.glLineWidth(1.5F);
+		GlStateManager.disableTexture2D();
+		GlStateManager.depthMask(false);
+		GlStateManager.enableBlend();
+		GlStateManager.disableDepth();
+		GlStateManager.disableLighting();
+		GlStateManager.disableCull();
+		GlStateManager.enableAlpha();
+		GlStateManager.color(1, 1, 1);
+	}
+
+	public static void begin(int mode) {
+		INSTANCE.getBuffer().begin(mode, DefaultVertexFormats.POSITION_COLOR);
+	}
+
+	public static void release() {
+		render();
+		releaseGL();
+	}
+
+	public static void render() {
+		INSTANCE.draw();
+	}
+
+	public static void releaseGL() {
+		GlStateManager.enableCull();
+		GlStateManager.depthMask(true);
+		GlStateManager.enableTexture2D();
+		GlStateManager.enableBlend();
+		GlStateManager.enableDepth();
+	}
+
+	public static void drawBox(BlockPos blockPos, int argb, int sides) {
+		final int a = (argb >>> 24) & 0xFF;
+		final int r = (argb >>> 16) & 0xFF;
+		final int g = (argb >>> 8) & 0xFF;
+		final int b = argb & 0xFF;
+		drawBox(blockPos, r, g, b, a, sides);
+	}
+
+	public static void drawBox(double x, double y, double z, int argb, int sides) {
+		drawBox(x, y, z, 1, 1, 1, argb, sides);
+	}
+
+	public static void drawBox(double x, double y, double z, double w, double h, double d, int argb, int sides) {
+		final int a = (argb >>> 24) & 0xFF;
+		final int r = (argb >>> 16) & 0xFF;
+		final int g = (argb >>> 8) & 0xFF;
+		final int b = argb & 0xFF;
+		drawBox(INSTANCE.getBuffer(), x, y, z, w, h, d, r, g, b, a, sides);
+	}
+
+	public static void drawBox(BlockPos blockPos, int r, int g, int b, int a, int sides) {
+		drawBox(INSTANCE.getBuffer(), blockPos.getX(), blockPos.getY(), blockPos.getZ(), 1, 1, 1, r, g, b, a, sides);
+	}
+
+	public static BufferBuilder getBufferBuilder() {
+		return INSTANCE.getBuffer();
+	}
+
+	public static void drawBox(final BufferBuilder buffer, double x, double y, double z, double w, double h, double d, int r, int g, int b, int a, int sides) {
+		if ((sides & GeometryMasks.Quad.DOWN) != 0) {
+			buffer.pos(x + w, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x, y, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Quad.UP) != 0) {
+			buffer.pos(x + w, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Quad.NORTH) != 0) {
+			buffer.pos(x + w, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Quad.SOUTH) != 0) {
+			buffer.pos(x, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Quad.WEST) != 0) {
+			buffer.pos(x, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Quad.EAST) != 0) {
+			buffer.pos(x + w, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+	}
+
+	public static void drawBoxOutline(final BufferBuilder buffer, float x, float y, float z, float w, float h, float d, int r, int g, int b, int a, int sides) {
+		if ((sides & GeometryMasks.Line.DOWN_WEST) != 0) {
+			buffer.pos(x, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.UP_WEST) != 0) {
+			buffer.pos(x, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.DOWN_EAST) != 0) {
+			buffer.pos(x + w, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.UP_EAST) != 0) {
+			buffer.pos(x + w, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.DOWN_NORTH) != 0) {
+			buffer.pos(x, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.UP_NORTH) != 0) {
+			buffer.pos(x, y + h, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.DOWN_SOUTH) != 0) {
+			buffer.pos(x, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.UP_SOUTH) != 0) {
+			buffer.pos(x, y + h, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.NORTH_WEST) != 0) {
+			buffer.pos(x, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.NORTH_EAST) != 0) {
+			buffer.pos(x + w, y, z).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.SOUTH_WEST) != 0) {
+			buffer.pos(x, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+
+		if ((sides & GeometryMasks.Line.SOUTH_EAST) != 0) {
+			buffer.pos(x + w, y, z + d).color(r, g, b, a).endVertex();
+			buffer.pos(x + w, y + h, z + d).color(r, g, b, a).endVertex();
+		}
+	}
+
+}


### PR DESCRIPTION
This PR aims to fully implement 3D objects to plethora's terminal glasses.
Contributors may want to reference #51 and the currently open issue #39

## Task list
- [X] Base: add support for 3D objects, rendering and seperating them from 2D objects
- [X] Box object
- [x] Line(s)
- [ ] Text
- [ ] (Custom) meshes
- [ ] Piramids
- [ ] Dot
- [ ] Ability to texture faces
- [ ] A better rendering system (modern openGL)
- [ ] Sort by distance when rendering objects so objects without depth testing don't look too odd
