### PR TITLE
Fix dead Tesla/Refined Storage maven repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,10 @@ repositories {
 	maven { url "http://maven.amadornes.com/" }
 
 	// Refined Storage
-	maven { url "http://dl.bintray.com/raoulvdberge/dev" }
+	maven { url "https://repo.raoulvdberge.com" }
 
 	// Tesla
-	maven { url 'http://maven.epoxide.xyz' }
+	maven { url 'http://maven.mcmoddev.com' }
 
 	// RF
 	maven { url = "http://maven.covers1624.net" }
@@ -118,7 +118,7 @@ dependencies {
 	compileOnly "slimeknights.mantle:Mantle:1.12-1.3.1.22"
 
 	compileOnly "MCMultiPart2:MCMultiPart:2.2.2:deobf"
-	compileOnly "refinedstorage:refinedstorage:1.5.33-1514:deobf"
+	compileOnly "refinedstorage:refinedstorage:1.5.35-16:deobf"
 	compileOnly("appeng:appliedenergistics2:rv5-stable-8") { exclude group: "mezz.jei" }
 	compileOnly("codechicken:ForgeMultipart:1.12-2.3.0.46:deobf") { exclude group: "codechicken" }
 	compileOnly "codechicken:CodeChickenLib:1.12-3.1.5.330:deobf"


### PR DESCRIPTION
The maven repos for Tesla and Refined Storage are dead, this PR switches to using the new ones. This does require bumping the Refined Storage version.