### PR TITLE
Implement #111 - Add methods for Forestry bee breeding data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ repositories {
 	// ConfigGen
 	maven { url = "https://dl.bintray.com/squiddev/maven" }
 
-	// IC2 API
+	// IC2 + Forestry
 	maven { url = "http://maven.ic2.player.to/" }
 
 	// Buildcraft
@@ -80,9 +80,6 @@ repositories {
 
 	// CBMP
 	maven { url "http://chickenbones.net/maven" }
-
-	// Forestry
-	maven { url "http://maven.ic2.player.to/" }
 }
 
 def curseMod(String mod, int id, String version) {

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ repositories {
 
 	// CBMP
 	maven { url "http://chickenbones.net/maven" }
+
+	// Forestry
+	maven { url "http://maven.ic2.player.to/" }
 }
 
 def curseMod(String mod, int id, String version) {
@@ -104,7 +107,7 @@ def curseMod(String mod, int id, String version) {
 
 dependencies {
 	compile "dan200.computercraft:ComputerCraft:${project.cc_version}-${project.cc_build}"
-	compile "mezz.jei:jei_1.12:4.7.0.68"
+	compile "mezz.jei:jei_1.12.2:4.9.1.192"
 
 	compileOnly "org.squiddev:cc-tweaked:1.80pr1.6"
 
@@ -123,9 +126,11 @@ dependencies {
 	compileOnly("codechicken:ForgeMultipart:1.12-2.3.0.46:deobf") { exclude group: "codechicken" }
 	compileOnly "codechicken:CodeChickenLib:1.12-3.1.5.330:deobf"
 
+	compileOnly "net.sengir.forestry:forestry_1.12.2:5.8.0.250:api"
+	compileOnly "net.sengir.forestry:forestry_1.12.2:5.8.0.250"
+
 	// All the Curse mods
 	compileOnly curseMod("botania", 2524591, "r1.10-353")
-	compileOnly curseMod("forestry", 2532388, "1.12.2-5.8.0.250")
 	compileOnly curseMod("baubles", 2518667, "1.12-1.5.2")
 	compileOnly curseMod("storage-drawers", 2536306, "1.12.2-5.3.5")
 	compileOnly curseMod("chameleon", 2450900, "1.12-4.1.3")

--- a/src/main/java/org/squiddev/plethora/core/PlethoraCore.java
+++ b/src/main/java/org/squiddev/plethora/core/PlethoraCore.java
@@ -25,6 +25,7 @@ import org.squiddev.plethora.core.capabilities.*;
 import org.squiddev.plethora.core.executor.TaskRunner;
 import org.squiddev.plethora.gameplay.Plethora;
 import org.squiddev.plethora.integration.computercraft.IntegrationComputerCraft;
+import org.squiddev.plethora.integration.forestry.IntegrationForestry;
 import org.squiddev.plethora.integration.vanilla.IntegrationVanilla;
 import org.squiddev.plethora.utils.DebugLogger;
 import org.squiddev.plethora.utils.Helpers;
@@ -61,6 +62,7 @@ public class PlethoraCore {
 		// Integration modules. Generally just listen to capability events
 		IntegrationComputerCraft.setup();
 		IntegrationVanilla.setup();
+		IntegrationForestry.setup();
 	}
 
 	@Mod.EventHandler

--- a/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
@@ -1,0 +1,33 @@
+package org.squiddev.plethora.integration.forestry;
+
+import com.google.common.base.Suppliers;
+import forestry.core.ModuleCore;
+import forestry.core.items.ItemAlyzer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.squiddev.plethora.api.module.BasicModuleHandler;
+import org.squiddev.plethora.core.PlethoraCore;
+
+import java.util.function.Supplier;
+
+public class IntegrationForestry {
+	public static final String analyzer = "forestry:analyzer";
+
+	public static void setup() {
+		MinecraftForge.EVENT_BUS.register(new IntegrationForestry());
+	}
+
+	@SubscribeEvent
+	public void attachCapabilitiesItem(AttachCapabilitiesEvent<ItemStack> event) {
+		if (event.getObject().getItem() instanceof ItemAlyzer) {
+			event.addCapability(PlethoraCore.PERIPHERAL_HANDLER_KEY, analyzerCapProvider.get());
+		}
+	}
+
+	private static final Supplier<BasicModuleHandler> analyzerCapProvider = Suppliers.memoize(() -> new BasicModuleHandler(
+			new ResourceLocation(analyzer), ModuleCore.getItems().portableAlyzer
+	));
+}

--- a/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
@@ -3,7 +3,9 @@ package org.squiddev.plethora.integration.forestry;
 import com.google.common.base.Suppliers;
 import forestry.core.ModuleCore;
 import forestry.core.items.ItemAlyzer;
+import forestry.core.tiles.TileAnalyzer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -27,6 +29,14 @@ public class IntegrationForestry {
 		}
 	}
 
+	@SubscribeEvent
+	public void attachCapabilitiesTile(AttachCapabilitiesEvent<TileEntity> event) {
+		if (event.getObject() instanceof TileAnalyzer) {
+			event.addCapability(PlethoraCore.PERIPHERAL_HANDLER_KEY, analyzerCapProvider.get());
+		}
+	}
+
+	// lazily evaluated to prevent runtime crashes because the item hasn't been registered yet
 	private static final Supplier<BasicModuleHandler> analyzerCapProvider = Suppliers.memoize(() -> new BasicModuleHandler(
 			new ResourceLocation(analyzer), ModuleCore.getItems().portableAlyzer
 	));

--- a/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
@@ -16,7 +16,7 @@ import org.squiddev.plethora.core.PlethoraCore;
 import java.util.function.Supplier;
 
 public class IntegrationForestry {
-	public static final String analyzer = "forestry:analyzer";
+	public static final String analyzerMod = "forestry:analyzer";
 
 	public static void setup() {
 		MinecraftForge.EVENT_BUS.register(new IntegrationForestry());
@@ -38,6 +38,6 @@ public class IntegrationForestry {
 
 	// lazily evaluated to prevent runtime crashes because the item hasn't been registered yet
 	private static final Supplier<BasicModuleHandler> analyzerCapProvider = Suppliers.memoize(() -> new BasicModuleHandler(
-			new ResourceLocation(analyzer), ModuleCore.getItems().portableAlyzer
+			new ResourceLocation(analyzerMod), ModuleCore.getItems().portableAlyzer
 	));
 }

--- a/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/IntegrationForestry.java
@@ -24,15 +24,15 @@ public class IntegrationForestry {
 		}
 	}
 
-	private static BasicModuleHandler _analyzerCap;
+	private static BasicModuleHandler analyzerCap;
 
 	@Optional.Method(modid = Constants.MOD_ID)
 	private static BasicModuleHandler getAnalyzerCap() {
-		if (_analyzerCap == null) {
-			_analyzerCap = new BasicModuleHandler(new ResourceLocation(analyzerMod), ModuleCore.getItems().portableAlyzer);
+		if (analyzerCap == null) {
+			analyzerCap = new BasicModuleHandler(new ResourceLocation(analyzerMod), ModuleCore.getItems().portableAlyzer);
 		}
 
-		return _analyzerCap;
+		return analyzerCap;
 	}
 
 	@SubscribeEvent

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MetaGenome.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MetaGenome.java
@@ -32,7 +32,7 @@ public class MetaGenome extends BasicMetaProvider<IGenome> {
 		return out;
 	}
 
-	private Object getAllele(IAllele allele) {
+	public static Object getAllele(IAllele allele) {
 		if (allele == null) {
 			return "missing";
 		} else if (allele instanceof IAlleleArea) {
@@ -62,6 +62,7 @@ public class MetaGenome extends BasicMetaProvider<IGenome> {
 			data.put("complexity", species.getComplexity());
 			data.put("humidity", species.getHumidity().getName());
 			data.put("temperature", species.getTemperature().getName());
+
 			return data;
 		} else if (allele instanceof IAlleleTolerance) {
 			return ((IAlleleTolerance) allele).getValue().toString().toLowerCase(Locale.ENGLISH);

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MetaGenome.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MetaGenome.java
@@ -22,8 +22,8 @@ public class MetaGenome extends BasicMetaProvider<IGenome> {
 		Map<String, Object> inactive = Maps.newHashMapWithExpectedSize(types.length);
 
 		for (IChromosomeType type : types) {
-			active.put(type.getName(), getAllele(genome.getActiveAllele(type)));
-			inactive.put(type.getName(), getAllele(genome.getInactiveAllele(type)));
+			active.put(type.getName(), getAlleleMeta(genome.getActiveAllele(type)));
+			inactive.put(type.getName(), getAlleleMeta(genome.getInactiveAllele(type)));
 		}
 
 		Map<Object, Object> out = Maps.newHashMap();
@@ -32,9 +32,9 @@ public class MetaGenome extends BasicMetaProvider<IGenome> {
 		return out;
 	}
 
-	public static Object getAllele(IAllele allele) {
+	public static Object getAlleleMeta(IAllele allele) {
 		if (allele == null) {
-			return "missing";
+			return null;
 		} else if (allele instanceof IAlleleArea) {
 			Vec3i vec = ((IAlleleArea) allele).getValue();
 

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MetaMutation.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MetaMutation.java
@@ -28,7 +28,7 @@ public class MetaMutation extends BasicMetaProvider<IMutation> {
 		for (IChromosomeType chromosome : karyotype) {
 			for (IAllele allele : mutation.getTemplate()) {
 				if (chromosome.getAlleleClass().isInstance(allele)) {
-					results.put(chromosome.getName(), MetaGenome.getAllele(allele));
+					results.put(chromosome.getName(), MetaGenome.getAlleleMeta(allele));
 				}
 			}
 		}

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MetaMutation.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MetaMutation.java
@@ -1,0 +1,49 @@
+package org.squiddev.plethora.integration.forestry;
+
+import com.google.common.collect.Maps;
+import forestry.api.genetics.IAllele;
+import forestry.api.genetics.IChromosomeType;
+import forestry.api.genetics.IMutation;
+import forestry.core.config.Constants;
+import org.squiddev.plethora.api.meta.BasicMetaProvider;
+import org.squiddev.plethora.integration.MetaWrapper;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+@MetaWrapper.MetaProvider.Inject(value = IMutation.class, modId = Constants.MOD_ID)
+public class MetaMutation extends BasicMetaProvider<IMutation> {
+	@Nonnull
+	@Override
+	public Map<Object, Object> getMeta(@Nonnull IMutation mutation) {
+		Map<Object, Object> out = Maps.newHashMapWithExpectedSize(5);
+
+		out.put("species1", mutation.getAllele0().getUID());
+		out.put("species2", mutation.getAllele1().getUID());
+		out.put("chance", mutation.getBaseChance());
+
+		IChromosomeType[] karyotype = mutation.getRoot().getKaryotype();
+		Map<String, Object> results = Maps.newHashMapWithExpectedSize(karyotype.length);
+
+		for (IChromosomeType chromosome : karyotype) {
+			for (IAllele allele : mutation.getTemplate()) {
+				if (chromosome.getAlleleClass().isInstance(allele)) {
+					results.put(chromosome.getName(), MetaGenome.getAllele(allele));
+				}
+			}
+		}
+
+		out.put("result", results);
+
+		Map<Integer, String> conditions = Maps.newHashMapWithExpectedSize(mutation.getSpecialConditions().size());
+		int i = 0;
+
+		for (String condition : mutation.getSpecialConditions()) {
+			conditions.put(++i, condition);
+		}
+
+		if (!conditions.isEmpty()) out.put("conditions", conditions);
+
+		return out;
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
@@ -7,7 +7,7 @@ import forestry.api.genetics.ISpeciesRoot;
 import forestry.core.config.Constants;
 import org.squiddev.plethora.api.method.IContext;
 import org.squiddev.plethora.api.module.IModuleContainer;
-import org.squiddev.plethora.api.module.ModuleObjectMethod;
+import org.squiddev.plethora.api.module.ModuleContainerObjectMethod;
 import org.squiddev.plethora.utils.LuaList;
 
 import java.util.Map;
@@ -15,7 +15,7 @@ import java.util.Map;
 import static forestry.api.genetics.AlleleManager.alleleRegistry;
 
 public class MethodsAnalyzer {
-	@ModuleObjectMethod.Inject(
+	@ModuleContainerObjectMethod.Inject(
 			module = IntegrationForestry.analyzerMod, worldThread = false, modId = Constants.MOD_ID,
 			doc = "function():table -- Get a list of all species roots"
 	)
@@ -29,7 +29,7 @@ public class MethodsAnalyzer {
 		return root;
 	}
 
-	@ModuleObjectMethod.Inject(
+	@ModuleContainerObjectMethod.Inject(
 			module = IntegrationForestry.analyzerMod, worldThread = false, modId = Constants.MOD_ID,
 			doc = "function(root:string):table -- Get a list of all species in the given species root"
 	)
@@ -47,7 +47,7 @@ public class MethodsAnalyzer {
 		return new Object[]{species.asMap()};
 	}
 
-	@ModuleObjectMethod.Inject(
+	@ModuleContainerObjectMethod.Inject(
 			module = IntegrationForestry.analyzerMod, worldThread = false, modId = Constants.MOD_ID,
 			doc = "function(root:string):table -- Get a list of all mutations in the given species root"
 	)

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
@@ -1,6 +1,5 @@
 package org.squiddev.plethora.integration.forestry;
 
-import com.google.common.collect.Maps;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.core.apis.ArgumentHelper;
 import forestry.api.genetics.IAlleleSpecies;
@@ -11,7 +10,6 @@ import org.squiddev.plethora.api.module.ModuleObjectMethod;
 import org.squiddev.plethora.utils.LuaList;
 
 import java.util.Map;
-import java.util.Set;
 
 import static forestry.api.genetics.AlleleManager.alleleRegistry;
 
@@ -21,15 +19,7 @@ public class MethodsAnalyzer {
 			doc = "function():table -- Get a list of all species roots"
 	)
 	public static Object[] getSpeciesRoots(IContext<IModuleContainer> context, Object[] args) {
-		Set<String> roots = alleleRegistry.getSpeciesRoot().keySet();
-		Map<Integer, String> out = Maps.newHashMapWithExpectedSize(roots.size());
-
-		int i = 0;
-		for (String root : roots) {
-			out.put(++i, root);
-		}
-
-		return new Object[] { out };
+		return new Object[]{new LuaList<>(alleleRegistry.getSpeciesRoot().keySet()).asMap()};
 	}
 
 	private static ISpeciesRoot getSpeciesRoot(String uid) throws LuaException {
@@ -46,13 +36,14 @@ public class MethodsAnalyzer {
 		String uid = ArgumentHelper.getString(args, 0);
 		ISpeciesRoot root = getSpeciesRoot(uid);
 
+		// please don't hurt me squid
 		LuaList<Object> species = alleleRegistry.getRegisteredAlleles(root.getSpeciesChromosomeType()).stream()
 				.map(IAlleleSpecies.class::cast)
 				.filter(s -> !s.isSecret())
 				.map(MetaGenome::getAlleleMeta)
 				.collect(LuaList.toLuaList());
 
-		return new Object[] { species.asMap() };
+		return new Object[]{species.asMap()};
 	}
 
 	@ModuleObjectMethod.Inject(
@@ -68,6 +59,6 @@ public class MethodsAnalyzer {
 				.map(m -> context.makePartialChild(m).getMeta())
 				.collect(LuaList.toLuaList());
 
-		return new Object[] { mutations.asMap() };
+		return new Object[]{mutations.asMap()};
 	}
 }

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
@@ -1,0 +1,73 @@
+package org.squiddev.plethora.integration.forestry;
+
+import com.google.common.collect.Maps;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.core.apis.ArgumentHelper;
+import forestry.api.genetics.IAlleleSpecies;
+import forestry.api.genetics.ISpeciesRoot;
+import org.squiddev.plethora.api.method.IContext;
+import org.squiddev.plethora.api.module.IModuleContainer;
+import org.squiddev.plethora.api.module.ModuleObjectMethod;
+import org.squiddev.plethora.utils.LuaList;
+
+import java.util.Map;
+import java.util.Set;
+
+import static forestry.api.genetics.AlleleManager.alleleRegistry;
+
+public class MethodsAnalyzer {
+	@ModuleObjectMethod.Inject(
+			module = IntegrationForestry.analyzer, worldThread = false,
+			doc = "function():table -- Get a list of all species roots"
+	)
+	public static Object[] getSpeciesRoots(IContext<IModuleContainer> context, Object[] args) {
+		Set<String> roots = alleleRegistry.getSpeciesRoot().keySet();
+		Map<Integer, String> out = Maps.newHashMapWithExpectedSize(roots.size());
+
+		int i = 0;
+		for (String root : roots) {
+			out.put(++i, root);
+		}
+
+		return new Object[] { out };
+	}
+
+	private static ISpeciesRoot getSpeciesRoot(String uid) throws LuaException {
+		ISpeciesRoot root = alleleRegistry.getSpeciesRoot(uid);
+		if (root == null) throw new LuaException("Species root " + uid + " does not exist");
+		return root;
+	}
+
+	@ModuleObjectMethod.Inject(
+			module = IntegrationForestry.analyzer, worldThread = false,
+			doc = "function(root:string):table -- Get a list of all species in the given species root"
+	)
+	public static Object[] getSpeciesList(IContext<IModuleContainer> context, Object[] args) throws LuaException {
+		String uid = ArgumentHelper.getString(args, 0);
+		ISpeciesRoot root = getSpeciesRoot(uid);
+
+		LuaList<Object> species = alleleRegistry.getRegisteredAlleles(root.getSpeciesChromosomeType()).stream()
+				.map(IAlleleSpecies.class::cast)
+				.filter(s -> !s.isSecret())
+				.map(MetaGenome::getAlleleMeta)
+				.collect(LuaList.toLuaList());
+
+		return new Object[] { species.asMap() };
+	}
+
+	@ModuleObjectMethod.Inject(
+			module = IntegrationForestry.analyzer, worldThread = false,
+			doc = "function(root:string):table -- Get a list of all mutations in the given species root"
+	)
+	public static Object[] getMutationsList(IContext<IModuleContainer> context, Object[] args) throws LuaException {
+		String uid = ArgumentHelper.getString(args, 0);
+		ISpeciesRoot root = getSpeciesRoot(uid);
+
+		LuaList<Map<Object, Object>> mutations = root.getMutations(false).stream()
+				.filter(s -> !s.isSecret())
+				.map(m -> context.makePartialChild(m).getMeta())
+				.collect(LuaList.toLuaList());
+
+		return new Object[] { mutations.asMap() };
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsAnalyzer.java
@@ -4,6 +4,7 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.core.apis.ArgumentHelper;
 import forestry.api.genetics.IAlleleSpecies;
 import forestry.api.genetics.ISpeciesRoot;
+import forestry.core.config.Constants;
 import org.squiddev.plethora.api.method.IContext;
 import org.squiddev.plethora.api.module.IModuleContainer;
 import org.squiddev.plethora.api.module.ModuleObjectMethod;
@@ -15,7 +16,7 @@ import static forestry.api.genetics.AlleleManager.alleleRegistry;
 
 public class MethodsAnalyzer {
 	@ModuleObjectMethod.Inject(
-			module = IntegrationForestry.analyzer, worldThread = false,
+			module = IntegrationForestry.analyzerMod, worldThread = false, modId = Constants.MOD_ID,
 			doc = "function():table -- Get a list of all species roots"
 	)
 	public static Object[] getSpeciesRoots(IContext<IModuleContainer> context, Object[] args) {
@@ -29,7 +30,7 @@ public class MethodsAnalyzer {
 	}
 
 	@ModuleObjectMethod.Inject(
-			module = IntegrationForestry.analyzer, worldThread = false,
+			module = IntegrationForestry.analyzerMod, worldThread = false, modId = Constants.MOD_ID,
 			doc = "function(root:string):table -- Get a list of all species in the given species root"
 	)
 	public static Object[] getSpeciesList(IContext<IModuleContainer> context, Object[] args) throws LuaException {
@@ -47,7 +48,7 @@ public class MethodsAnalyzer {
 	}
 
 	@ModuleObjectMethod.Inject(
-			module = IntegrationForestry.analyzer, worldThread = false,
+			module = IntegrationForestry.analyzerMod, worldThread = false, modId = Constants.MOD_ID,
 			doc = "function(root:string):table -- Get a list of all mutations in the given species root"
 	)
 	public static Object[] getMutationsList(IContext<IModuleContainer> context, Object[] args) throws LuaException {

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsBeeHousing.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsBeeHousing.java
@@ -1,15 +1,10 @@
 package org.squiddev.plethora.integration.forestry;
 
-import com.google.common.collect.Maps;
 import forestry.api.apiculture.IBeeHousing;
-import forestry.api.core.IErrorState;
 import forestry.core.config.Constants;
 import net.minecraft.item.ItemStack;
 import org.squiddev.plethora.api.method.BasicObjectMethod;
 import org.squiddev.plethora.api.method.IContext;
-
-import java.util.Collection;
-import java.util.Map;
 
 public class MethodsBeeHousing {
 	@BasicObjectMethod.Inject(
@@ -52,20 +47,5 @@ public class MethodsBeeHousing {
 	)
 	public static Object[] getHumidity(IContext<IBeeHousing> context, Object[] arg) {
 		return new Object[]{context.getTarget().getHumidity().getName()};
-	}
-
-	@BasicObjectMethod.Inject(
-		value = IBeeHousing.class, modId = Constants.MOD_ID, worldThread = true,
-		doc = "function():table -- Get the errors which are preventing the bees from working."
-	)
-	public static Object[] getErrors(IContext<IBeeHousing> context, Object[] arg) {
-		Collection<IErrorState> states = context.getTarget().getErrorLogic().getErrorStates();
-
-		int i = 0;
-		Map<Integer, String> out = Maps.newHashMapWithExpectedSize(states.size());
-		for (IErrorState state : states) {
-			out.put(++i, state.getUniqueName());
-		}
-		return new Object[]{out};
 	}
 }

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsBeeHousing.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsBeeHousing.java
@@ -1,19 +1,14 @@
 package org.squiddev.plethora.integration.forestry;
 
 import com.google.common.collect.Maps;
-import forestry.api.apiculture.IAlleleBeeSpecies;
 import forestry.api.apiculture.IBeeHousing;
-import forestry.api.apiculture.IBeeRoot;
 import forestry.api.core.IErrorState;
-import forestry.api.genetics.*;
 import forestry.core.config.Constants;
 import net.minecraft.item.ItemStack;
 import org.squiddev.plethora.api.method.BasicObjectMethod;
 import org.squiddev.plethora.api.method.IContext;
-import org.squiddev.plethora.utils.DebugLogger;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class MethodsBeeHousing {
@@ -72,48 +67,5 @@ public class MethodsBeeHousing {
 			out.put(++i, state.getUniqueName());
 		}
 		return new Object[]{out};
-	}
-
-	private static ISpeciesRoot getBeeRoot() {
-		return AlleleManager.alleleRegistry.getSpeciesRoot("rootBees");
-	}
-
-	@BasicObjectMethod.Inject(
-			value = IBeeHousing.class, modId = Constants.MOD_ID, worldThread = false,
-			doc = "function():table -- Get a list of all bee species"
-	)
-	public static Object[] getSpeciesList(IContext<IBeeHousing> context, Object[] arg) {
-		ISpeciesRoot beeRoot = getBeeRoot();
-		IChromosomeType speciesType = beeRoot.getSpeciesChromosomeType();
-		Collection<IAllele> allSpecies = AlleleManager.alleleRegistry.getRegisteredAlleles(speciesType);
-		Map<Integer, Object> out = Maps.newHashMapWithExpectedSize(beeRoot.getSpeciesCount());
-
-		int i = 0;
-		for (IAllele allele : allSpecies) {
-			if (((IAlleleSpecies) allele).isSecret()) continue;
-
-			out.put(++i, MetaGenome.getAllele(allele));
-		}
-
-		return new Object[] { out };
-	}
-
-	@BasicObjectMethod.Inject(
-			value = IBeeHousing.class, modId = Constants.MOD_ID, worldThread = false,
-			doc = "function():table -- Get a list of all bee mutations"
-	)
-	public static Object[] getMutationsList(IContext<IBeeHousing> context, Object[] arg) {
-		ISpeciesRoot beeRoot = getBeeRoot();
-		List<? extends IMutation> mutations = beeRoot.getMutations(false);
-		Map<Integer, Map<Object, Object>> out = Maps.newHashMapWithExpectedSize(mutations.size());
-
-		int i = 0;
-		for (IMutation mutation : mutations) {
-			if (mutation.isSecret()) continue;
-
-			out.put(++i, context.makePartialChild(mutation).getMeta());
-		}
-
-		return new Object[] { out };
 	}
 }

--- a/src/main/java/org/squiddev/plethora/integration/forestry/MethodsErrorLogicSource.java
+++ b/src/main/java/org/squiddev/plethora/integration/forestry/MethodsErrorLogicSource.java
@@ -1,0 +1,22 @@
+package org.squiddev.plethora.integration.forestry;
+
+import forestry.api.core.IErrorLogicSource;
+import forestry.api.core.IErrorState;
+import forestry.core.config.Constants;
+import org.squiddev.plethora.api.method.BasicObjectMethod;
+import org.squiddev.plethora.api.method.IContext;
+import org.squiddev.plethora.utils.LuaList;
+
+public class MethodsErrorLogicSource {
+	@BasicObjectMethod.Inject(
+			value = IErrorLogicSource.class, modId = Constants.MOD_ID, worldThread = true,
+			doc = "function():table -- Get any errors preventing operation"
+	)
+	public static Object[] getErrors(IContext<IErrorLogicSource> context, Object[] arg) {
+		return new Object[] {
+				context.getTarget().getErrorLogic().getErrorStates().stream()
+						.map(IErrorState::getUniqueName)
+						.collect(LuaList.toLuaList()).asMap()
+		};
+	}
+}

--- a/src/main/java/org/squiddev/plethora/utils/LuaList.java
+++ b/src/main/java/org/squiddev/plethora/utils/LuaList.java
@@ -1,0 +1,52 @@
+package org.squiddev.plethora.utils;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.stream.Collector;
+
+public class LuaList<T> {
+	/**
+	 * Creates a {@link Collector} that produces a LuaList
+	 */
+	public static <T>Collector<T, ?, LuaList<T>> toLuaList() {
+		return Collector.of(
+				LuaList::new,
+				LuaList::add,
+				(a, b) -> {
+					b.map.values().forEach(a::add);
+					return a;
+				},
+				Collector.Characteristics.IDENTITY_FINISH
+		);
+	}
+
+	private final Map<Integer, T> map;
+	private int lastIndex = 0;
+
+	public LuaList() {
+		map = Maps.newHashMap();
+	}
+
+	/**
+	 * Creates a new, empty LuaList
+	 * @param expectedSize The expected size of this list
+	 */
+	public LuaList(int expectedSize) {
+		map = Maps.newHashMapWithExpectedSize(expectedSize);
+	}
+
+	/**
+	 * Adds an element to the end of the list
+	 */
+	public void add(T e) {
+		map.put(++lastIndex, e);
+	}
+
+	/**
+	 * Converts the list to a map of 1-indexed integer keys to values
+	 */
+	public Map<Integer, T> asMap() {
+		return map;
+	}
+}

--- a/src/main/java/org/squiddev/plethora/utils/LuaList.java
+++ b/src/main/java/org/squiddev/plethora/utils/LuaList.java
@@ -2,9 +2,13 @@ package org.squiddev.plethora.utils;
 
 import com.google.common.collect.Maps;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collector;
 
+/**
+ * A simple wrapper class for constructing Lua lists. Not thread safe!
+ */
 public class LuaList<T> {
 	/**
 	 * Creates a {@link Collector} that produces a LuaList
@@ -24,16 +28,27 @@ public class LuaList<T> {
 	private final Map<Integer, T> map;
 	private int lastIndex = 0;
 
+	/**
+	 * Creates a new, empty list
+	 */
 	public LuaList() {
 		map = Maps.newHashMap();
 	}
 
 	/**
-	 * Creates a new, empty LuaList
+	 * Creates a new, empty list
 	 * @param expectedSize The expected size of this list
 	 */
 	public LuaList(int expectedSize) {
 		map = Maps.newHashMapWithExpectedSize(expectedSize);
+	}
+
+	/**
+	 * Creates a new list using elements from the given {@link Collection}
+	 */
+	public LuaList(Collection<T> of) {
+		this(of.size());
+		addAll(of);
 	}
 
 	/**
@@ -44,7 +59,14 @@ public class LuaList<T> {
 	}
 
 	/**
-	 * Converts the list to a map of 1-indexed integer keys to values
+	 * Adds all elements from the given {@link Iterable}
+	 */
+	public void addAll(Iterable<T> from) {
+		from.forEach(this::add);
+	}
+
+	/**
+	 * Returns this list as a {@link Map} of 1-indexed integer keys to values
 	 */
 	public Map<Integer, T> asMap() {
 		return map;


### PR DESCRIPTION
Here's an implementation for #111:

- Uses Maven for Forestry so the API is available
- Bumps JEI version to prevent runtime conflicts (Forestry requires a newer version of JEI)
- Adds `getSpeciesRoots`, `getSpeciesList`, and `getMutationsList` to the portable analyzer when used in a manipulator (secret species/mutations are not included of course)
- Adds `LuaList`, simple wrapper type for returning lists

Screenshots:

- `getSpeciesRoots`
![image](https://user-images.githubusercontent.com/5429337/40593240-2665e4d0-61f5-11e8-999a-aa00634a2001.png)

- `getSpeciesList`
![image](https://user-images.githubusercontent.com/5429337/40593245-379764f4-61f5-11e8-8fbd-1bf5b9abaea4.png)

- `getMutationsList`
![image](https://user-images.githubusercontent.com/5429337/40593250-4b09548e-61f5-11e8-9524-8c0f2d0d5a17.png)
![image](https://user-images.githubusercontent.com/5429337/40593257-54ea0174-61f5-11e8-9ab5-30986058d5aa.png)

