### PR TITLE
Add method to get IC2 reactor core from chamber

### DIFF
--- a/src/main/java/org/squiddev/plethora/integration/ic2/MethodsReactor.java
+++ b/src/main/java/org/squiddev/plethora/integration/ic2/MethodsReactor.java
@@ -1,0 +1,50 @@
+package org.squiddev.plethora.integration.ic2;
+
+import dan200.computercraft.api.lua.LuaException;
+import ic2.api.reactor.IReactor;
+import ic2.api.reactor.IReactorChamber;
+import ic2.core.IC2;
+import net.minecraft.tileentity.TileEntity;
+import org.squiddev.plethora.api.method.BasicObjectMethod;
+import org.squiddev.plethora.api.method.IContext;
+import org.squiddev.plethora.api.reference.DynamicReference;
+
+import javax.annotation.Nonnull;
+
+public class MethodsReactor {
+	private static class ReactorReference extends DynamicReference<IReactor> {
+		private final IReactor core;
+		private final TileEntity expected;
+
+		ReactorReference(IReactor core) {
+			this.core = core;
+			this.expected = core.getCoreTe();
+		}
+
+		@Nonnull
+		@Override
+		public IReactor get() throws LuaException {
+			if (core.getCoreTe() != expected) {
+				throw new LuaException("The reactor has changed");
+			}
+
+			return core;
+		}
+
+		@Nonnull
+		@Override
+		public IReactor safeGet() throws LuaException {
+			return core;
+		}
+	}
+
+	@BasicObjectMethod.Inject(
+			value = IReactorChamber.class, worldThread = true, modId = IC2.MODID,
+			doc = "function():table -- Get a reference to the reactor's core"
+	)
+	public static Object[] getReactorCore(IContext<IReactorChamber> context, Object[] args) {
+		IReactor core = context.getTarget().getReactorInstance();
+		return new Object[] { context.makeChild(core, new ReactorReference(core)).getObject() };
+	}
+
+}


### PR DESCRIPTION
This adds a method to get a reference to the IC2 reactor core from a chamber, so that you can use plethora with full scale EU and pressurized reactors The validity check for the `ReactorReference` could probably be improved.