### PR TITLE
Initial stab at a testing server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ jar {
 configurations {
 	integrationMod
 	compileOnly.extendsFrom integrationMod
+	testCompile.extendsFrom integrationMod
+	testCompile.extendsFrom forgeGradleGradleStart
 }
 
 repositories {
@@ -88,8 +90,8 @@ dependencies {
 	integrationMod "cofh:ThermalExpansion:1.12.2-5.5.3.41:universal"
 	integrationMod "cofh:ThermalFoundation:1.12.2-2.6.2.26:universal"
 	integrationMod "cofh:CoFHWorld:1.12.2-1.3.0.6:universal"
-	integrationMod ("com.enderio:EnderIO:1.12.2-5.0.40") { transitive = false }
-	integrationMod  "com.enderio.core:EnderCore:1.12.2-0.5.51"
+	compileOnly   ("com.enderio:EnderIO:1.12.2-5.0.40") { transitive = false }
+	compileOnly    "com.enderio.core:EnderCore:1.12.2-0.5.51" // EnderCore appears to crash in a development environment.
 	integrationMod("com.github.mcjty:mcjtylib:1.12-3.1.1") { transitive = false }
 	integrationMod("com.github.mcjty:rftools:1.12-7.60") { transitive = false }
 	integrationMod("com.github.mcjty:xnet:1.12-1.7.6_beta2") { transitive = false }

--- a/src/test/java/org/squiddev/plethora/boostrap/HowlCiStub.java
+++ b/src/test/java/org/squiddev/plethora/boostrap/HowlCiStub.java
@@ -1,0 +1,121 @@
+package org.squiddev.plethora.boostrap;
+
+import dan200.computercraft.api.filesystem.IFileSystem;
+import dan200.computercraft.api.lua.IComputerSystem;
+import dan200.computercraft.api.lua.ILuaAPI;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.core.filesystem.FileMount;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import org.apache.logging.log4j.Level;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+
+import static dan200.computercraft.core.apis.ArgumentHelper.getString;
+
+/**
+ * Mimics parts of the howlci library, or at least those required by mcfly.
+ */
+public class HowlCiStub implements ILuaAPI {
+	private final IComputerSystem computer;
+
+	HowlCiStub(IComputerSystem computer) {
+		this.computer = computer;
+	}
+
+	@Override
+	public String[] getNames() {
+		return new String[]{"howlci"};
+	}
+
+	@Nonnull
+	@Override
+	public String[] getMethodNames() {
+		return new String[]{"log", "status"};
+	}
+
+	@Override
+	public void startup() {
+		IFileSystem fs = computer.getFileSystem();
+		if (fs == null) {
+			PlethoraTestMod.LOG.error("Cannot find filesystem");
+			return;
+		}
+
+		try {
+			File testRom = new File("../../src/test/resources/assets/plethora-test/test-rom").getCanonicalFile();
+			if (!testRom.isDirectory()) {
+				PlethoraTestMod.LOG.error("Cannot find test-rom (looked at {}", testRom);
+				return;
+			}
+
+			computer.mount("test-rom", new FileMount(testRom, 0L));
+
+			if (fs.exists("startup.lua")) fs.delete("startup.lua");
+			fs.copy("test-rom/startup.lua", "startup.lua");
+		} catch (IOException e) {
+			PlethoraTestMod.LOG.error("Cannot create startup file", e);
+		}
+
+		PlethoraTestMod.LOG.info("Setup test-rom");
+	}
+
+	@Nullable
+	@Override
+	public Object[] callMethod(@Nonnull ILuaContext context, int method, @Nonnull Object[] arguments) throws LuaException, InterruptedException {
+		switch (method) {
+			case 0: { // log
+				String level = getString(arguments, 0);
+				String message = getString(arguments, 1);
+				PlethoraTestMod.LOG.log(getEnum(level, Level.INFO, Level.values()), message);
+				return null;
+			}
+			case 1: { // status
+				String status = getString(arguments, 0);
+				String test = getString(arguments, 1);
+
+				FMLCommonHandler.instance().getMinecraftServerInstance()
+					.sendMessage(getEnum(status, Status.PENDING).format(test));
+				return null;
+			}
+			default:
+				return null;
+		}
+	}
+
+	private static <T extends Enum<T>> T getEnum(String name, T def) {
+		return getEnum(name, def, def.getDeclaringClass().getEnumConstants());
+	}
+
+	private static <T> T getEnum(String name, T def, T[] values) {
+		for (T value : values) {
+			if (value.toString().equalsIgnoreCase(name)) return value;
+		}
+		return def;
+	}
+
+	private enum Status {
+		PENDING(TextFormatting.YELLOW),
+		ERROR(TextFormatting.DARK_PURPLE),
+		FAIL(TextFormatting.RED),
+		PASS(TextFormatting.GREEN);
+
+		private final TextFormatting colour;
+
+		Status(TextFormatting colour) {
+			this.colour = colour;
+		}
+
+		public ITextComponent format(String string) {
+			TextComponentString component = new TextComponentString(string);
+			component.getStyle().setColor(colour);
+			return component;
+		}
+	}
+}

--- a/src/test/java/org/squiddev/plethora/boostrap/LaunchServer.java
+++ b/src/test/java/org/squiddev/plethora/boostrap/LaunchServer.java
@@ -1,0 +1,72 @@
+package org.squiddev.plethora.boostrap;
+
+import net.minecraftforge.gradle.GradleStartCommon;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+public final class LaunchServer extends GradleStartCommon {
+	private static final Logger LOG = LogManager.getLogger();
+
+
+	@Override
+	protected String getTweakClass() {
+		return "net.minecraftforge.fml.common.launcher.FMLServerTweaker";
+	}
+
+	@Override
+	protected String getBounceClass() {
+		return "net.minecraft.launchwrapper.Launch";
+	}
+
+	@Override
+	protected void preLaunch(Map<String, String> argMap, List<String> extras) {
+	}
+
+	@Override
+	protected void setDefaultArguments(Map<String, String> argMap) {
+	}
+
+	public static void main(String[] args) throws Throwable {
+		// Verify we're running from the correct directory.
+		File rootDir = new File(".").getCanonicalFile();
+		if (!rootDir.getName().equals("server") || !rootDir.getParentFile().getName().equals("test-files")) {
+			LOG.error("Should run test server from 'test-files/server' directory");
+			System.exit(1);
+			return;
+		}
+
+		File eulaFile = new File(rootDir, "eula.txt");
+		if (!eulaFile.exists()) {
+			LOG.warn("EULA has not been signed, generating it.");
+			// OK, I know this is super dubious. But one needs a way to automate this.
+			try (Writer writer = new OutputStreamWriter(new FileOutputStream(eulaFile), StandardCharsets.UTF_8)) {
+				writer.write("# Automatically generated EULA. Please don't use this for a real server.\neula=true\n");
+			}
+		}
+
+		File propertiesFile = new File(rootDir, "server.properties");
+		if (!propertiesFile.exists()) {
+			LOG.warn("server.properties has not been written, generating it");
+			try (Writer writer = new OutputStreamWriter(new FileOutputStream(propertiesFile), StandardCharsets.UTF_8)) {
+				writer.write("level-type=FLAT\n");
+				writer.write("gamemode=1\n");
+				writer.write("online-mode=false\n");
+				writer.write("enable-command-block=true\n");
+			}
+		}
+
+		System.setProperty("java.awt.headless", "true"); // No GUI
+		System.setProperty("buildcraft.debug", "disable"); // No Buildcraft logging
+
+		LOG.info("Launching Minecraft in {}", rootDir);
+		new LaunchServer().launch(new String[]{"--username", "PlethoraDev"});
+	}
+}

--- a/src/test/java/org/squiddev/plethora/boostrap/PlethoraTestMod.java
+++ b/src/test/java/org/squiddev/plethora/boostrap/PlethoraTestMod.java
@@ -1,0 +1,109 @@
+package org.squiddev.plethora.boostrap;
+
+import dan200.computercraft.ComputerCraft;
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.shared.computer.blocks.TileCommandComputer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeChunkManager;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+
+@Mod(
+	modid = PlethoraTestMod.ID,
+	name = "Plethora Test Runner",
+	version = "1.0.0",
+	dependencies = "required-after:plethora;required-after:plethora-core"
+)
+public class PlethoraTestMod implements ForgeChunkManager.OrderedLoadingCallback {
+	static final String ID = "plethora-test";
+
+	static final Logger LOG = LogManager.getLogger(ID);
+
+	private ForgeChunkManager.Ticket ticket;
+
+	@Mod.EventHandler
+	public void preInit(FMLPreInitializationEvent event) {
+		ForgeChunkManager.setForcedChunkLoadingCallback(this, this);
+		ComputerCraftAPI.registerAPIFactory(HowlCiStub::new);
+	}
+
+	@Mod.EventHandler
+	public void onServerStarted(FMLServerStartedEvent event) {
+		MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
+		World world = server.getWorld(0);
+
+		// Stop all the clocks, cut off the telephone.
+		GameRules gamerules = world.getGameRules();
+		gamerules.setOrCreateGameRule("doMobSpawning", "false");
+		gamerules.setOrCreateGameRule("doDaylightCycle", "false");
+		gamerules.setOrCreateGameRule("doWeatherCycle", "false");
+		for (World serverWorld : server.worlds) if (serverWorld != null) serverWorld.setWorldTime(6000);
+
+		LOG.info("Dumping methods and metadata providers");
+		server.getCommandManager().executeCommand(server, "plethora dump plethora-docs.json");
+		server.getCommandManager().executeCommand(server, "plethora dump plethora-docs.html");
+
+		// Force the chunk at (0, 0) to be loaded.
+		if (ticket == null) {
+			LOG.info("Acquiring a new chunkloading ticket");
+			ticket = ForgeChunkManager.requestTicket(this, world, ForgeChunkManager.Type.NORMAL);
+		}
+		ForgeChunkManager.forceChunk(ticket, new ChunkPos(0, 0));
+		LOG.info("Forced chunk at (0, 0)");
+
+		setupChunk(world);
+	}
+
+	@Override
+	public void ticketsLoaded(List<ForgeChunkManager.Ticket> tickets, World world) {
+	}
+
+	@Override
+	public List<ForgeChunkManager.Ticket> ticketsLoaded(List<ForgeChunkManager.Ticket> tickets, World world, int maxTicketCount) {
+		return Collections.emptyList();
+	}
+
+	public static void setupChunk(World world) {
+		// Clear the chunk of all blocks.
+		BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(0, 0, 0);
+		IBlockState state = Blocks.AIR.getDefaultState();
+		for (int y = 0; y < 256; y++) {
+			for (int x = 0; x < 16; x++) {
+				for (int z = 0; z < 16; z++) {
+					pos.setPos(x, y, z);
+					world.setBlockState(pos, state);
+				}
+			}
+		}
+		LOG.info("Cleared chunk at (0, 0)");
+
+		BlockPos computerPos = new BlockPos(7, 128, 7);
+		world.setBlockState(computerPos, ComputerCraft.Blocks.commandComputer.getDefaultState());
+
+		TileEntity tile = world.getTileEntity(computerPos);
+		if (!(tile instanceof TileCommandComputer)) {
+			LOG.error("Expected TileCommandComputer, got {}", tile);
+			return;
+		}
+
+		TileCommandComputer computer = (TileCommandComputer) tile;
+		computer.setComputerID(0);
+		computer.setLabel("Test Runner");
+		computer.createProxy().turnOn();
+		LOG.info("Created computer at " + computerPos);
+	}
+}

--- a/src/test/java/org/squiddev/plethora/core/wrapper/PlethoraMethodRegistryTest.java
+++ b/src/test/java/org/squiddev/plethora/core/wrapper/PlethoraMethodRegistryTest.java
@@ -57,9 +57,9 @@ public class PlethoraMethodRegistryTest {
 		Method method = MethodsVanillaTileEntities.class.getMethod("getSignText", TileEntitySign.class);
 		assertTrue(PlethoraMethodRegistry.add(method));
 
-		TileEntitySign furnace = new TileEntitySign();
+		TileEntitySign sign = new TileEntitySign();
 		TypedLuaObject<TileEntitySign> object = ContextFactory
-			.of(furnace, id(furnace))
+			.of(sign, id(sign))
 			.withExecutor(BasicExecutor.INSTANCE)
 			.getObject();
 

--- a/src/test/resources/assets/plethora-test/test-rom/mcfly.lua
+++ b/src/test/resources/assets/plethora-test/test-rom/mcfly.lua
@@ -1,0 +1,432 @@
+--- A very basic test framework for ComputerCraft
+--
+-- Like Busted (http://olivinelabs.com/busted/), but more memorable.
+--
+-- @usage
+-- describe("something to test", function()
+--   it("some property", function()
+--     expect(some_function()):equals("What it should equal")
+--   end)
+-- end)
+
+--- Assert an argument to the given function has the specified type.
+--
+-- @tparam string The function's name
+-- @tparam int    The argument index to this function
+-- @tparam string The type this argument should have. May be 'value' for any
+--                non-nil value.
+-- @param val     The value to check
+-- @raise If this value doesn't match the expected type.
+local function check(func, arg, ty, val)
+	if ty == 'value' then
+		if val == nil then
+			error(('%s: bad argument #%d (got nil)'):format(func, arg), 3)
+		end
+	elseif type(val) ~= ty then
+		return error(('%s: bad argument #%d (expected %s, got %s)'):format(func, arg, ty, type(val)), 3)
+	end
+end
+
+local error_mt = { __tostring = function(self) return self.message end }
+
+--- Attempt to execute the provided function, gathering a stack trace when it
+-- errors.
+--
+-- @tparam
+-- @return[1] true
+-- @return[2] false
+-- @return[2] The error object
+local function try(fn)
+	if not debug or not debug.traceback then
+		local ok, err = pcall(fn)
+		if ok or getmetatable(err) == error_mt then
+			return ok, err
+		else
+			return ok, setmetatable({ message = tostring(err) }, error_mt)
+		end
+	end
+
+	local ok, err = xpcall(fn, function(err)
+		return { message = err, trace = debug.traceback() }
+	end)
+
+	-- Restore a whole bunch of state
+	io.input(io.stdin)
+	io.output(io.stdout)
+
+	-- If we're an existing error, or we succeded then propagate it.
+	if ok then return ok, err end
+	if type(err) ~= "table" then
+		return setmetatable({ message = tostring(err) }, error_mt)
+	end
+
+	if getmetatable(err.message) == error_mt then return ok, err.message end
+
+	-- Find the common substring between the two traces. Yes, this is horrible.
+	local trace = debug.traceback()
+	for i = 1, #trace do
+		if trace:sub(-i) ~= err.trace:sub(-i) then
+			err.trace = err.trace:sub(1, -i)
+			break
+		end
+	end
+
+	return ok, setmetatable(err, error_mt)
+end
+
+--- Fail a test with the given message
+--
+-- @tparam string message The message to fail with
+-- @raises An error with the given message
+local function fail(message)
+	check('fail', 1, 'string', message)
+	error(setmetatable({ message = message, fail = true }, error_mt))
+end
+
+--- Format an object in order to make it more readable
+--
+-- @param value The value to format
+-- @treturn string The formatted value
+local function format(value)
+	-- TODO: Look into something like mbs's pretty printer.
+	local ok, res = pcall(textutils.serialise, value)
+	if ok then return res else return tostring(value) end
+end
+
+local expect_mt = {}
+expect_mt.__index = expect_mt
+
+--- Assert that this expectation has the provided value
+--
+-- @param value The value to require this expectation to be equal to
+-- @raises If the values are not equal
+function expect_mt:equals(value)
+	if value ~= self.value then
+		fail(("Expected %s\n but got %s"):format(format(value), format(self.value)))
+	end
+
+	return self
+end
+expect_mt.equal = expect_mt.equals
+expect_mt.eq = expect_mt.equals
+
+--- Assert that this expectation does not equal the provided value
+--
+-- @param value The value to require this expectation to not be equal to
+-- @raises If the values are equal
+function expect_mt:not_equals(value)
+	if value == self.value then
+		fail(("Expected any value but %s"):format(format(value)))
+	end
+
+	return self
+end
+expect_mt.not_equal = expect_mt.not_equals
+expect_mt.ne = expect_mt.not_equals
+
+--- Assert that this expectation has something of the provided type
+--
+-- @tparam string exp_type The type to require this expectation to have
+-- @raises If it does not have that thpe
+function expect_mt:type(exp_type)
+	local actual_type = type(self.value)
+	if exp_type ~= actual_type then
+		fail(("Expected value of type %s\n                   got %s"):format(exp_type, actual_type))
+	end
+
+	return self
+end
+
+local function matches(eq, exact, left, right)
+	if left == right then return true end
+
+	local ty = type(left)
+	if ty ~= type(right) or ty ~= "table" then return false end
+
+	-- If we've already explored/are exploring the left and right then return
+	if eq[left] and eq[left][right] then return true end
+	if not eq[left]  then eq[left] = {[right] = true} else eq[left][right] = true end
+	if not eq[right] then eq[right] = {[left] = true} else eq[right][left] = true end
+
+	-- Verify all pairs in left are equal to those in right
+	for k, v in pairs(left) do
+		if not matches(eq, exact, v, right[k]) then return false end
+	end
+
+	if exact then
+		-- And verify all pairs in right are present in left
+		for k in pairs(right) do
+			if left[k] == nil then return false end
+		end
+	end
+
+	return true
+end
+
+--- Assert that this expectation is structurally equivalent to
+-- the provided object.
+--
+-- @param value The value to check for structural equivalence
+-- @raises If they are not equivalent
+function expect_mt:same(value)
+	if not matches({}, true, self.value, value) then
+		fail(("Expected %s\n but got %s"):format(format(value), format(self.value)))
+	end
+
+	return self
+end
+
+--- Assert that this expectation contains all fields mentioned
+-- in the provided object.
+--
+-- @param value The value to check against
+-- @raises If this does not match the provided value
+function expect_mt:matches(value)
+	if not matches({}, false, value, self.value) then
+		fail(("Expected %s\nto match %s"):format(format(self.value), format(value)))
+	end
+
+	return self
+end
+
+--- Construct a new expectation from the provided value
+--
+-- @param value The value to apply assertions to
+-- @return The new expectation
+local function expect(value)
+	return setmetatable({ value = value}, expect_mt)
+end
+
+--- The stack of "describe"s.
+local test_stack = { n = 0 }
+
+--- Whether we're now running tests, and so cannot run any more.
+local tests_locked = false
+
+--- The list of tests that we'll run
+local test_list, test_map, test_count = { }, { }, 0
+
+--- Add a new test to our queue.
+--
+-- @param test The descriptor of this test
+local function do_test(test)
+	-- Set the name if it doesn't already exist
+	if not test.name then test.name = table.concat(test_stack, "\0", 1, test_stack.n) end
+	test_count = test_count + 1
+	test_list[test_count] = test
+	test_map[test.name] = test_count
+end
+
+--- Get the "friendly" name of this test.
+--
+-- @treturn string This test's friendly name
+local function test_name(test) return (test.name:gsub("\0", " \26 ")) end
+
+--- Describe something which will be tested, such as a function or situation
+--
+-- @tparam string name   The name of the object to test
+-- @tparam function body A function which describes the tests for this object.
+local function describe(name, body)
+	check('describe', 1, 'string', name)
+	check('describe', 2, 'function', body)
+	if tests_locked then error("Cannot describe something while running tests", 2) end
+
+	-- Push our name onto the stack, eval and pop it
+	local n = test_stack.n + 1
+	test_stack[n], test_stack.n = name, n
+
+	local ok, err = try(body)
+
+	-- We count errors as a (failing) test.
+	if not ok then do_test { error = err } end
+
+	test_stack.n = n - 1
+end
+
+--- Declare a single test within a context
+--
+-- @tparam string name   What you are testing
+-- @tparam function body A function which runs the test, failing if it does
+--                       the assertions are not met.
+local function it(name, body)
+	check('it', 1, 'string', name)
+	check('it', 2, 'function', body)
+	if tests_locked then error("Cannot create test while running tests", 2) end
+
+	-- Push name onto the stack
+	local n = test_stack.n + 1
+	test_stack[n], test_stack.n, tests_locked = name, n, true
+
+	do_test { action = body }
+
+	-- Pop the test from the stack
+	test_stack.n, tests_locked = n - 1, false
+end
+
+--- Declare a single not-yet-implemented test
+--
+-- @tparam string name   What you really should be testing but aren't
+local function pending(name)
+	check('it', 1, 'string', name)
+	if tests_locked then error("Cannot create test while running tests", 2) end
+
+	local _, loc = pcall(error, "", 3)
+	loc = loc:gsub(":%s*$", "")
+
+	local n = test_stack.n + 1
+	test_stack[n], test_stack.n = name, n
+	do_test { pending = true, trace = loc }
+	test_stack.n = n - 1
+end
+
+local arg = ...
+if arg == "--help" or arg == "-h" then
+	io.write("Usage: mcfly [DIR]\n")
+	io.write("\n")
+	io.write("Run tests in the provided DIRectory, or `spec` if not given.")
+	return
+end
+
+local root_dir = shell.resolve(arg or "spec")
+if not fs.isDir(root_dir) then
+	io.stderr:write(("%q is not a directory.\n"):format(root_dir))
+	error()
+end
+
+do
+	-- Load in the tests from all our files
+	local env = setmetatable({
+		expect = expect, fail = fail,
+		describe = describe, it = it, pending = pending
+	}, { __index = _ENV })
+
+	local suffix = "_spec.lua"
+	local function run_in(sub_dir)
+		for _, name in ipairs(fs.list(sub_dir)) do
+			local file = fs.combine(sub_dir, name)
+			if fs.isDir(file) then
+				run_in(file)
+			elseif file:sub(-#suffix) == suffix then
+				local fun, err = loadfile(file, env)
+				if not fun then
+					do_test { name = file:sub(#root_dir + 2), error = { message = err } }
+				else
+					local ok, err = try(fun)
+					if not ok then do_test { name = file:sub(#root_dir + 2), error = err } end
+				end
+			end
+		end
+	end
+
+	run_in(root_dir)
+end
+
+-- Error if we've found no tests
+if test_count == 0 then
+	io.stderr:write(("Could not find any tests in %q\n"):format(root_dir))
+	error()
+end
+
+-- The results of each test, as well as how many passed and the count.
+local test_results, test_status, tests_run = { n = 0 }, {}, 0
+
+-- All possible test statuses
+local statuses = {
+	pass    = { desc = "Pass",    col = colours.green,   dot = "\7"   }, -- Circle
+	fail    = { desc = "Failed",  col = colours.red,     dot = "\4"   }, -- Diamond
+	error   = { desc = "Error",   col = colours.magenta, dot = "\4"   },
+	pending = { desc = "Pending", col = colours.yellow,  dot = "\186" }, -- Hollow circle
+}
+
+-- Set up each test status count.
+for k in pairs(statuses) do test_status[k] = 0 end
+
+--- Do the actual running of our test
+local function do_run(test)
+	-- If we're a pre-computed test, determine our status message. Otherwise,
+	-- skip.
+	local status, err
+	if test.pending then
+		status = "pending"
+	elseif test.error then
+		err = test.error
+		status = "error"
+	elseif test.action then
+		local ok
+		ok, err = try(test.action)
+		status = ok and "pass" or (err.fail and "fail" or "error")
+	end
+
+	-- If we've a boolean status, then convert it into a string
+	if status == true then status = "pass"
+	elseif status == false then status = err.fail and "fail" or "error"
+	end
+
+	tests_run = tests_run + 1
+	test_status[status] = test_status[status] + 1
+	test_results[tests_run] = {
+		status = status, name = test.name,
+		message = test.message or err and err.message,
+		trace = test.trace or err and err.trace,
+	}
+
+	-- If we're running under howlci, then log some info.
+	if howlci then howlci.status(status, test_name(test)) end
+	if cct_test then cct_test.submit(test_results[tests_run]) end
+
+	-- Print our progress dot
+	local data = statuses[status]
+	term.setTextColour(data.col) io.write(data.dot)
+	term.setTextColour(colours.white)
+end
+
+-- Loop over all our tests, running them as required.
+if cct_test then
+	-- If we're within a cct_test environment, then submit them and wait on tests
+	-- to be run.
+	cct_test.start(test_map)
+	while true do
+		local _, name = os.pullEvent("cct_test_run")
+		if not name then break end
+		do_run(test_list[test_map[name]])
+	end
+else
+	for _, test in pairs(test_list) do do_run(test) end
+end
+
+-- Otherwise, display the results of each failure
+io.write("\n\n")
+for i = 1, tests_run do
+	local test = test_results[i]
+	if test.status ~= "pass" then
+		local status_data = statuses[test.status]
+
+		term.setTextColour(status_data.col)
+		io.write(status_data.desc)
+		term.setTextColour(colours.white)
+		io.write(" \26 " .. test_name(test) .. "\n")
+
+		if test.message then
+			io.write("  " .. test.message:gsub("\n", "\n  ") .. "\n")
+		end
+
+		if test.trace then
+			term.setTextColour(colours.lightGrey)
+			io.write("  " .. test.trace:gsub("\n", "\n  ") .. "\n")
+		end
+
+		io.write("\n")
+	end
+end
+
+-- And some summary statistics
+local actual_count = tests_run - test_status.pending
+local info = ("Ran %s test(s), of which %s passed (%g%%).")
+	:format(actual_count, test_status.pass, (test_status.pass / actual_count) * 100)
+
+if test_status.pending > 0 then
+	info = info .. (" Skipped %d pending test(s)."):format(test_status.pending)
+end
+
+term.setTextColour(colours.white) io.write(info .. "\n")
+if howlci then howlci.log("info", info) sleep(0.5) end

--- a/src/test/resources/assets/plethora-test/test-rom/spec/vanilla/inventory_spec.lua
+++ b/src/test/resources/assets/plethora-test/test-rom/spec/vanilla/inventory_spec.lua
@@ -1,0 +1,38 @@
+describe("inventories", function()
+	local function setup()
+		commands.wait {
+			commands.async.setblock("~", "~1", "~", "minecraft:air"),
+			commands.async.setblock("~", "~1", "~", "minecraft:chest", 0, "replace", {
+				Items = { { Slot = 0, id = "minecraft:stick", Count = 50 } }
+			}),
+		}
+
+		return peripheral.wrap("top")
+	end
+
+	it("size", function()
+		local inv = setup()
+		expect(inv.size()):eq(27)
+	end)
+
+	it("list", function()
+		local inv = setup()
+		expect(inv.list()):same { { name = "minecraft:stick", damage = 0, count = 50 } }
+	end)
+
+	describe("getItemMetdata", function()
+		it("on an empty slot", function()
+			local inv = setup()
+			expect(inv.getItemMeta(2)):eq(nil)
+		end)
+
+		it("on a stick", function()
+			local inv = setup()
+			expect(inv.getItemMeta(1)):same {
+				name = "minecraft:stick", displayName = "Stick", rawName = "item.stick",
+				damage = 0, maxDamage = 0, count = 50, maxCount = 64,
+				ores = { stickWood = true }
+			}
+		end)
+	end)
+end)

--- a/src/test/resources/assets/plethora-test/test-rom/startup.lua
+++ b/src/test/resources/assets/plethora-test/test-rom/startup.lua
@@ -1,0 +1,97 @@
+local old_print, old_printError = print, printError
+local function log(x)
+	local a = fs.open("log.txt", "a")
+	a.writeLine(x)
+	a.close()
+end
+
+local function print(msg)
+	old_print(msg)
+	log(msg)
+	commands.say(msg)
+end
+
+local function printError(msg)
+	old_printError(msg)
+	log(msg)
+	commands.say(msg)
+end
+
+--- Waits for one or more commands to finish, and verifies they have all been executed successfully.
+--
+-- @usage commands.wait { commands.async.say("Testing"), commands.async.say("things!") }
+function commands.wait(commands)
+	local n, remaining = #commands, {}
+	for i = 1, n do
+		remaining[commands[i]] = i
+	end
+
+	while n > 0 do
+		local _, id, ok, res = os.pullEvent("task_complete")
+		local i = remaining[id]
+		if i then
+			n = n - 1
+			remaining[id] = nil
+
+			if not ok then
+				error(("Command %d failed: %s"):format(i, res), 2)
+			end
+		end
+	end
+end
+
+local ok, err = pcall(function()
+	print("Booting test monitor")
+
+	if not fs.exists("cloud.lua") then
+		local request, err = http.get("https://cloud-catcher.squiddev.cc/cloud.lua")
+		if not request then
+			printError(("Cannot load cloud-catcher (%s)"):format(err))
+		else
+			local contents = request.readAll()
+			request.close()
+
+			local handle = fs.open("cloud.lua", "w")
+			handle.write(contents)
+			handle.close()
+
+			print("Fetched cloud-catcher")
+		end
+	end
+
+	print(("Run '/computercraft queue #%d cloud|test' to control the test runner"):format(os.getComputerID()))
+
+	while true do
+		local command = table.pack(os.pullEvent("computer_command"))
+		if command[2] == "cloud" then
+			if cloud then
+				printError("Already running cloud-catcher")
+			else
+				local token = command[3]
+				if not token then
+					-- Generate a random token.
+					local tok_items = {}
+					for i = 1, 32 do
+						local idx = math.random(36)
+						tok_items[i] = ("abcdefghijklmnopqrstuvwxyz0123456789"):sub(idx, idx)
+					end
+					token = table.concat(tok_items)
+				end
+
+				print(("Visit https://cloud-catcher.squiddev.cc/?id=%s to control the computer"):format(token))
+				shell.run("bg", "cloud.lua", "-t80x30", token)
+			end
+		elseif command[2] == "test" then
+			print("Running tests")
+			shell.run("test-rom/mcfly.lua test-rom/spec")
+		else
+			printError("Unknown command")
+		end
+	end
+end)
+
+if not ok then
+	printError(tostring(err))
+end
+
+os.shutdown()

--- a/src/test/resources/mcmod.info
+++ b/src/test/resources/mcmod.info
@@ -1,0 +1,9 @@
+[
+	{
+		"modid": "plethora-test",
+		"description": "Test runner for Plethora",
+		"credits": "Dan200, Forge team",
+		"authorList": [ "SquidDev" ],
+		"dependencies": [ "plethora", "plethora-core" ]
+	}
+]

--- a/src/test/resources/pack.mcmeta
+++ b/src/test/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+   "pack":{
+      "pack_format":1,
+      "description":"Plethora"
+   }
+}


### PR DESCRIPTION
This provides a mechanism for starting a Minecraft server with all supported mods loaded. Once started, we dump documentation and start a "testing computer". One can then run automated programs on this computer.

## Documentation generation
This was a bit of a stab at solving #198. Aside from EnderIO, I'm able to successfully load up all mods and build a massive documentation dump. I suspect the next step will be to split this into separate mods (would be pretty cool to split some things into sub-components of a mod too), and write a summary for each of them.

## Automated testing
So part of this change involves an very basic test-suite runner, as demonstrated here:

![image](https://user-images.githubusercontent.com/4346137/56361658-d45d5b00-61df-11e9-9324-5729ca3e74fb.png)

The idea here is that a command computer can set up an environment, run some tests, and then destroy the environment again. Partially the aim of this is partly to avoid dumb regressions like fc983fd0e34faa3f433baaaba49ff988bee5435e, but also give me some sane way to verify the more complex mod integrations (i.e. AE, RS) are still working.

This is very much just a POC right now. I've written a grand total of four tests, and while it's pretty cool, I'm not sure how useful it'll be in practice.

It would be possible to integrate the testing mechanism into JUnit, which is what we do for CC:T. However, given that most of the time is spent actually starting the server, rather than running tests, it doesn't seem worth it right now.