### PR TITLE
Lines in 3D canvasses

### DIFF
--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
@@ -14,13 +14,11 @@ import org.squiddev.plethora.gameplay.modules.glasses.CanvasServer;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectGroup;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectGroup.Group3D;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectGroup.Origin3D;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Box;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Item3D;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.ObjectFrame;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.ObjectRoot3D;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.*;
 
 import static dan200.computercraft.core.apis.ArgumentHelper.optInt;
 import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
+import static org.squiddev.plethora.api.method.ArgumentHelper.optFloat;
 import static org.squiddev.plethora.gameplay.modules.glasses.objects.Colourable.DEFAULT_COLOUR;
 
 public final class MethodsCanvas3D {
@@ -86,6 +84,34 @@ public final class MethodsCanvas3D {
 		canvas.add(box);
 
 		return baked.makeChild(box, canvas.reference(box)).getObject();
+	}
+
+	@PlethoraMethod(worldThread = false,
+		doc = "function(startX:number, startY:number, startZ:number, endX:number, endY:number, endZ:number[, thickness:number, color:number] -- Create a new line."
+	)
+	public static TypedLuaObject<Line3D> addLine(IContext<Group3D> baked, @FromContext CanvasServer canvas, Object[] args) throws LuaException {
+		double startX = getFloat(args, 0);
+		double startY = getFloat(args, 1);
+		double startZ = getFloat(args, 2);
+
+		double endX = getFloat(args, 3);
+		double endY = getFloat(args, 4);
+		double endZ = getFloat(args, 5);
+
+		float thickness = optFloat(args, 6, 1.0f);
+		int colour = optInt(args, 7, DEFAULT_COLOUR);
+
+		Group3D group = baked.getTarget();
+
+		Line3D line = new Line3D(canvas.newObjectId(), group.id());
+		line.setPosition(new Vec3d(startX, startY, startZ));
+		line.setEndPosition(new Vec3d(endX, endY, endZ));
+		line.setScale(thickness);
+		line.setColour(colour);
+
+		canvas.add(line);
+
+		return baked.makeChild(line, canvas.reference(line)).getObject();
 	}
 
 	@PlethoraMethod(doc = "-- Create a item model.", worldThread = false)

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
@@ -86,9 +86,7 @@ public final class MethodsCanvas3D {
 		return baked.makeChild(box, canvas.reference(box)).getObject();
 	}
 
-	@PlethoraMethod(worldThread = false,
-		doc = "-- Create a new line."
-	)
+	@PlethoraMethod(doc = "-- Create a new line.", worldThread = false)
 	public static TypedLuaObject<Line3D> addLine(
 		IContext<Group3D> baked, @FromContext CanvasServer canvas,
 		Vec3d start, Vec3d end,
@@ -97,8 +95,8 @@ public final class MethodsCanvas3D {
 		Group3D group = baked.getTarget();
 
 		Line3D line = new Line3D(canvas.newObjectId(), group.id());
-		line.setPosition(start);
-		line.setEndPosition(end);
+		line.setVertex(0, start);
+		line.setVertex(1, end);
 		line.setScale(thickness);
 		line.setColour(colour);
 

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
@@ -89,23 +89,16 @@ public final class MethodsCanvas3D {
 	@PlethoraMethod(worldThread = false,
 		doc = "function(startX:number, startY:number, startZ:number, endX:number, endY:number, endZ:number[, thickness:number, color:number] -- Create a new line."
 	)
-	public static TypedLuaObject<Line3D> addLine(IContext<Group3D> baked, @FromContext CanvasServer canvas, Object[] args) throws LuaException {
-		double startX = getFloat(args, 0);
-		double startY = getFloat(args, 1);
-		double startZ = getFloat(args, 2);
-
-		double endX = getFloat(args, 3);
-		double endY = getFloat(args, 4);
-		double endZ = getFloat(args, 5);
-
-		float thickness = optFloat(args, 6, 1.0f);
-		int colour = optInt(args, 7, DEFAULT_COLOUR);
-
+	public static TypedLuaObject<Line3D> addLine(
+		IContext<Group3D> baked, @FromContext CanvasServer canvas,
+		Vec3d start, Vec3d end,
+		@Optional(defDoub = 1.0f) float thickness, @Optional(defInt = DEFAULT_COLOUR) int colour
+	) {
 		Group3D group = baked.getTarget();
 
 		Line3D line = new Line3D(canvas.newObjectId(), group.id());
-		line.setPosition(new Vec3d(startX, startY, startZ));
-		line.setEndPosition(new Vec3d(endX, endY, endZ));
+		line.setPosition(start);
+		line.setEndPosition(end);
 		line.setScale(thickness);
 		line.setColour(colour);
 

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
@@ -87,7 +87,7 @@ public final class MethodsCanvas3D {
 	}
 
 	@PlethoraMethod(worldThread = false,
-		doc = "function(startX:number, startY:number, startZ:number, endX:number, endY:number, endZ:number[, thickness:number, color:number] -- Create a new line."
+		doc = "-- Create a new line."
 	)
 	public static TypedLuaObject<Line3D> addLine(
 		IContext<Group3D> baked, @FromContext CanvasServer canvas,

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/ObjectRegistry.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/ObjectRegistry.java
@@ -4,10 +4,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import org.squiddev.plethora.gameplay.modules.glasses.BaseObject;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.object2d.*;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Box;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.Item3D;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.ObjectFrame;
-import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.ObjectRoot3D;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.*;
 
 public final class ObjectRegistry {
 	public static final byte RECTANGLE_2D = 0;
@@ -24,6 +21,7 @@ public final class ObjectRegistry {
 	public static final byte FRAME_3D = 10;
 	public static final byte BOX_3D = 11;
 	public static final byte ITEM_3D = 12;
+	public static final byte LINE_3D = 13;
 
 	private static final BaseObject.Factory[] FACTORIES = new BaseObject.Factory[]{
 		Rectangle::new,
@@ -40,6 +38,7 @@ public final class ObjectRegistry {
 		ObjectFrame::new,
 		Box::new,
 		Item3D::new,
+		Line3D::new
 	};
 
 	private ObjectRegistry() {

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
@@ -110,7 +110,7 @@ public class Line3D extends ColourableObject implements Positionable3D, DepthTes
 			setDirty();
 		}
 	}
-	
+
 	public void setEndPosition(@Nonnull Vec3d position) {
 		if (!Objects.equal(this.end, position)) {
 			this.end = position;

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
@@ -11,9 +11,6 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
-import org.squiddev.plethora.api.method.MethodResult;
-import org.squiddev.plethora.api.method.wrapper.FromTarget;
-import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
 import org.squiddev.plethora.gameplay.modules.glasses.CanvasClient;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.ColourableObject;
 import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectRegistry;
@@ -22,7 +19,7 @@ import org.squiddev.plethora.utils.ByteBufUtils;
 
 import javax.annotation.Nonnull;
 
-public class Line3D extends ColourableObject implements Positionable3D, DepthTestable, Scalable {
+public class Line3D extends ColourableObject implements MultiPoint3D, DepthTestable, Scalable {
 	private Vec3d start;
 	private Vec3d end;
 
@@ -31,6 +28,44 @@ public class Line3D extends ColourableObject implements Positionable3D, DepthTes
 
 	public Line3D(int id, int parent) {
 		super(id, parent, ObjectRegistry.LINE_3D);
+	}
+
+	@Nonnull
+	@Override
+	public Vec3d getPoint(int idx) {
+		switch (idx) {
+			case 0:
+				return start;
+			case 1:
+				return end;
+			default:
+				throw new IndexOutOfBoundsException("No vertex #" + idx);
+		}
+	}
+
+	@Override
+	public void setVertex(int idx, @Nonnull Vec3d point) {
+		switch (idx) {
+			case 0:
+				if (!Objects.equal(start, point)) {
+					start = point;
+					setDirty();
+				}
+				break;
+			case 1:
+				if (!Objects.equal(end, point)) {
+					end = point;
+					setDirty();
+				}
+				break;
+			default:
+				throw new IndexOutOfBoundsException("No vertex #" + idx);
+		}
+	}
+
+	@Override
+	public int getVertices() {
+		return 2;
 	}
 
 	@Override
@@ -90,42 +125,6 @@ public class Line3D extends ColourableObject implements Positionable3D, DepthTes
 		end = ByteBufUtils.readVec3d(buf);
 		thickness = buf.readFloat();
 		depthTest = buf.readBoolean();
-	}
-
-	@Nonnull
-	@Override
-	public Vec3d getPosition() {
-		return start;
-	}
-
-	@Nonnull
-	public Vec3d getEndPosition() {
-		return end;
-	}
-
-	@Override
-	public void setPosition(@Nonnull Vec3d position) {
-		if (!Objects.equal(this.start, position)) {
-			this.start = position;
-			setDirty();
-		}
-	}
-
-	public void setEndPosition(@Nonnull Vec3d position) {
-		if (!Objects.equal(this.end, position)) {
-			this.end = position;
-			setDirty();
-		}
-	}
-
-	@PlethoraMethod(doc = "function():number, number, number -- Get the end position of this line.", worldThread = false)
-	public static MethodResult getEndPosition(@FromTarget Line3D line) {
-		return MethodResult.result(line.end.x, line.end.y, line.end.z);
-	}
-
-	@PlethoraMethod(doc = "function(endX:number, endY:number, endZ:number) -- Set the end position of this line.", worldThread = false)
-	public static void setEndPosition(@FromTarget Line3D line, float endX, float endY, float endZ) {
-		line.setEndPosition(new Vec3d(endX, endY, endZ));
 	}
 
 	@Override

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Line3D.java
@@ -1,0 +1,144 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.opengl.GL11;
+import org.squiddev.plethora.api.method.MethodResult;
+import org.squiddev.plethora.api.method.wrapper.FromTarget;
+import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
+import org.squiddev.plethora.gameplay.modules.glasses.CanvasClient;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ColourableObject;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.ObjectRegistry;
+import org.squiddev.plethora.gameplay.modules.glasses.objects.Scalable;
+import org.squiddev.plethora.utils.ByteBufUtils;
+
+import javax.annotation.Nonnull;
+
+public class Line3D extends ColourableObject implements Positionable3D, DepthTestable, Scalable {
+	private Vec3d start;
+	private Vec3d end;
+
+	private float thickness = 1.0f;
+	private boolean depthTest = true;
+
+	public Line3D(int id, int parent) {
+		super(id, parent, ObjectRegistry.LINE_3D);
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void draw(CanvasClient canvas) {
+		setupFlat();
+
+		if (start != null && end != null) {
+			if (depthTest) {
+				GlStateManager.enableDepth();
+			} else {
+				GlStateManager.disableDepth();
+			}
+
+			GlStateManager.glLineWidth(thickness);
+			GL11.glEnable(GL11.GL_LINE_SMOOTH);
+
+			Tessellator tessellator = Tessellator.getInstance();
+			BufferBuilder buffer = tessellator.getBuffer();
+			buffer.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION_COLOR);
+			buffer.pos(start.x, start.y, start.z).color(getRed(), getGreen(), getBlue(), getAlpha()).endVertex();
+			buffer.pos(end.x, end.y, end.z).color(getRed(), getGreen(), getBlue(), getAlpha()).endVertex();
+
+			tessellator.draw();
+
+			GL11.glDisable(GL11.GL_LINE_SMOOTH);
+			GlStateManager.glLineWidth(1.0f);
+		}
+	}
+
+	@Override
+	public boolean hasDepthTest() {
+		return depthTest;
+	}
+
+	@Override
+	public void setDepthTest(boolean depthTest) {
+		if (this.depthTest != depthTest) {
+			this.depthTest = depthTest;
+			setDirty();
+		}
+	}
+
+	@Override
+	public void writeInitial(ByteBuf buf) {
+		super.writeInitial(buf);
+		ByteBufUtils.writeVec3d(buf, start);
+		ByteBufUtils.writeVec3d(buf, end);
+		buf.writeFloat(thickness);
+		buf.writeBoolean(depthTest);
+	}
+
+	@Override
+	public void readInitial(ByteBuf buf) {
+		super.readInitial(buf);
+		start = ByteBufUtils.readVec3d(buf);
+		end = ByteBufUtils.readVec3d(buf);
+		thickness = buf.readFloat();
+		depthTest = buf.readBoolean();
+	}
+
+	@Nonnull
+	@Override
+	public Vec3d getPosition() {
+		return start;
+	}
+
+	@Nonnull
+	public Vec3d getEndPosition() {
+		return end;
+	}
+
+	@Override
+	public void setPosition(@Nonnull Vec3d position) {
+		if (!Objects.equal(this.start, position)) {
+			this.start = position;
+			setDirty();
+		}
+	}
+	
+	public void setEndPosition(@Nonnull Vec3d position) {
+		if (!Objects.equal(this.end, position)) {
+			this.end = position;
+			setDirty();
+		}
+	}
+
+	@PlethoraMethod(doc = "function():number, number, number -- Get the end position of this line.", worldThread = false)
+	public static MethodResult getEndPosition(@FromTarget Line3D line) {
+		return MethodResult.result(line.end.x, line.end.y, line.end.z);
+	}
+
+	@PlethoraMethod(doc = "function(endX:number, endY:number, endZ:number) -- Set the end position of this line.", worldThread = false)
+	public static void setEndPosition(@FromTarget Line3D line, float endX, float endY, float endZ) {
+		line.setEndPosition(new Vec3d(endX, endY, endZ));
+	}
+
+	@Override
+	public float getScale() {
+		return thickness;
+	}
+
+	@Override
+	public void setScale(float scale) {
+		if (thickness != scale) {
+			// Large line widths can behave weirdly on some hardware (or not work at all), so let's keep it sane.
+			this.thickness = MathHelper.clamp(scale, 1.0f, 5.0f);
+			setDirty();
+		}
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/MultiPoint3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/MultiPoint3D.java
@@ -1,0 +1,37 @@
+package org.squiddev.plethora.gameplay.modules.glasses.objects.object3d;
+
+import dan200.computercraft.api.lua.LuaException;
+import net.minecraft.util.math.Vec3d;
+import org.squiddev.plethora.api.method.MethodResult;
+import org.squiddev.plethora.api.method.wrapper.FromTarget;
+import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
+
+import javax.annotation.Nonnull;
+
+import static org.squiddev.plethora.api.method.ArgumentHelper.assertBetween;
+
+/**
+ * A three-dimensional polygon for which you can set multiple vertices.
+ */
+public interface MultiPoint3D {
+	@Nonnull
+	Vec3d getPoint(int idx);
+
+	void setVertex(int idx, @Nonnull Vec3d point);
+
+	int getVertices();
+
+	@PlethoraMethod(doc = "function(idx:int):number, number -- Get the specified vertex of this object.", worldThread = false)
+	static MethodResult getPoint(@FromTarget MultiPoint3D object, int idx) throws LuaException {
+		assertBetween(idx, 1, object.getVertices(), "Index out of range (%s)");
+
+		Vec3d point = object.getPoint(idx - 1);
+		return MethodResult.result(point.x, point.y, point.z);
+	}
+
+	@PlethoraMethod(doc = "-- Set the specified vertex of this object.", worldThread = false)
+	static void setPoint(@FromTarget MultiPoint3D object, int idx, double x, double y, double z) throws LuaException {
+		assertBetween(idx, 1, object.getVertices(), "Index out of range (%s)");
+		object.setVertex(idx - 1, new Vec3d(x, y, z));
+	}
+}

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/MultiPoint3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/MultiPoint3D.java
@@ -21,7 +21,7 @@ public interface MultiPoint3D {
 
 	int getVertices();
 
-	@PlethoraMethod(doc = "function(idx:int):number, number -- Get the specified vertex of this object.", worldThread = false)
+	@PlethoraMethod(doc = "function(idx:int):number, number, number -- Get the specified vertex of this object.", worldThread = false)
 	static MethodResult getPoint(@FromTarget MultiPoint3D object, int idx) throws LuaException {
 		assertBetween(idx, 1, object.getVertices(), "Index out of range (%s)");
 


### PR DESCRIPTION
Fairly straight forward PR, this allows us to draw three-dimensional lines on overlay glasses.

I wasn't entirely sure whether to make a `MultiPoint3D` interface just for this, so I went with a `setEndPosition` method instead. However, having such an interface might be useful if we wanted to add other polygons like triangles later? Opinions?