### PR TITLE
RFTools and XNet Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,13 +93,13 @@ dependencies {
 	compileOnly   ("com.enderio:EnderIO:1.12.2-5.0.43") { transitive = false }
 	compileOnly    "com.enderio.core:EnderCore:1.12.2-0.5.57" // EnderCore appears to crash in a development environment.
 	//FIXME Revert these to `integrationMod` before merging
-	compile("com.github.mcjty:mcjtylib:1.12-3.5.0") { transitive = false }
-	compile("com.github.mcjty:rftools:1.12-7.70") { transitive = false }
-	compile("mcjty.rftoolsctrl:rftoolsctrl:1.12-1.9.1") { transitive = false }
-	compile("com.github.mcjty:xnet:1.12-1.8.0") { transitive = false }
+	deobfCompile("com.github.mcjty:mcjtylib:1.12-3.5.0") { transitive = false }
+	deobfCompile("com.github.mcjty:rftools:1.12-7.70") { transitive = false }
+	deobfCompile("mcjty.rftoolsctrl:rftoolsctrl:1.12-2.0.1") { transitive = false }
+	deobfCompile("com.github.mcjty:xnet:1.12-1.8.0") { transitive = false }
 	integrationMod "com.mod-buildcraft:buildcraft-all:7.99.22"
 	integrationMod "hellfirepvp.astralsorcery:astralsorcery:1.12.2-1.10.18-v129"
-	integrationMod "MCMultiPart2:MCMultiPart:2.5.4"
+	integrationMod "MCMultiPart2:MCMultiPart:2.5.3"
 	integrationMod "net.darkhax.tesla:Tesla-1.12.2:1.0.63"
 	integrationMod "net.industrial-craft:industrialcraft-2:2.8.146-ex112"
 	integrationMod "net.sengir.forestry:forestry_1.12.2:5.8.2.387:api"
@@ -120,7 +120,7 @@ dependencies {
 	integrationMod "hatchery:hatchery:1.12.2:2.2.1"
 	//FIXME Switch to `integrationMod` before merging
 	//TODO See if this is available via the k-4u.nl Maven repo
-	compile("rftools-dimensions:rftoolsdim:1.12:5.64") { transitive = false }
+	deobfCompile("rftools-dimensions:rftoolsdim:1.12:5.70") { transitive = false }
 
 	compileOnly('org.squiddev:ConfigGen:1.2.5') { exclude group: 'net.minecraftforge' }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,9 +90,11 @@ dependencies {
 	integrationMod "cofh:CoFHWorld:1.12.2-1.3.0.6:universal"
 	integrationMod ("com.enderio:EnderIO:1.12.2-5.0.40") { transitive = false }
 	integrationMod  "com.enderio.core:EnderCore:1.12.2-0.5.51"
-	integrationMod("com.github.mcjty:mcjtylib:1.12-3.1.1") { transitive = false }
-	integrationMod("com.github.mcjty:rftools:1.12-7.60") { transitive = false }
-	integrationMod("com.github.mcjty:xnet:1.12-1.7.6_beta2") { transitive = false }
+	//FIXME Revert these to `integrationMod` before merging
+	compile("com.github.mcjty:mcjtylib:1.12-3.1.1") { transitive = false }
+	compile("com.github.mcjty:rftools:1.12-7.60") { transitive = false }
+	compile("mcjty.rftoolsctrl:rftoolsctrl:1.12-1.9.1") { transitive = false }
+	compile("com.github.mcjty:xnet:1.12-1.7.6_beta2") { transitive = false }
 	integrationMod "com.mod-buildcraft:buildcraft-all:7.99.22"
 	integrationMod "hellfirepvp.astralsorcery:astralsorcery:1.12.2-1.10.12-v80"
 	integrationMod "MCMultiPart2:MCMultiPart:2.5.3"
@@ -114,6 +116,9 @@ dependencies {
 	integrationMod "roost:roost:1.12:1.3.0"
 	integrationMod "chickens:chickens:6.0.4"
 	integrationMod "hatchery:hatchery:1.12.2:2.2.1"
+	//FIXME Switch to `integrationMod` before merging
+	//TODO See if this is available via the k-4u.nl Maven repo
+	compile("rftools-dimensions:rftoolsdim:1.12:5.64") { transitive = false }
 
 	compileOnly('org.squiddev:ConfigGen:1.2.5') { exclude group: 'net.minecraftforge' }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 mc_version=1.12.2
-forge_version=14.23.5.2768
+//forge_version=14.23.5.2768
+forge_version=14.23.5.2800
+//FIXME Revert before merging; required by McJtyLib
 
 mod_version=1.2.0
 cct_version=1.82.3

--- a/src/main/java/org/squiddev/plethora/integration/mcjtylib/IntegrationMcJtyLib.java
+++ b/src/main/java/org/squiddev/plethora/integration/mcjtylib/IntegrationMcJtyLib.java
@@ -2,14 +2,21 @@ package org.squiddev.plethora.integration.mcjtylib;
 
 import mcjty.lib.McJtyLib;
 import mcjty.lib.base.GeneralConfig;
+import mcjty.lib.blocks.GenericItemBlock;
 import mcjty.lib.tileentity.GenericTileEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.Constants;
 import org.squiddev.plethora.api.Injects;
 import org.squiddev.plethora.api.meta.BasicMetaProvider;
 import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.api.meta.ItemStackMetaProvider;
 import org.squiddev.plethora.utils.EntityPlayerDummy;
 import org.squiddev.plethora.utils.WorldDummy;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -19,18 +26,28 @@ public final class IntegrationMcJtyLib {
 	private IntegrationMcJtyLib() {
 	}
 
+	/*
+	 * MEMO To test McJtyLib and dependent integrations, Forge must be set to AT LEAST 14.23.5.2800
+	 */
+
 	public static final IMetaProvider<GenericTileEntity> META_GENERIC_TILE = new BasicMetaProvider<GenericTileEntity>() {
 
 		@Nonnull
 		@Override
 		public Map<String, ?> getMeta(@Nonnull GenericTileEntity context) {
-			Map<String, Object> out = new HashMap<>(4);
+			Map<String, Object> out = new HashMap<>(5);
 
-			if (!GeneralConfig.manageOwnership) {
-				out.put("ownerName", context.getOwnerName());
+			if (GeneralConfig.manageOwnership) {
+				//TODO Do we want to expose the UUID, if set, regardless of the owner's name?
+				// That is, how closely do we want to mimic the results of `mcjty.lib.tileentity.GenericTileEntity.addProbeInfo`
+				String ownerName = context.getOwnerName();
+				if (ownerName != null && !ownerName.isEmpty()) out.put("ownerName", ownerName);
 
 				UUID owner = context.getOwnerUUID();
 				if (owner != null) out.put("ownerUUID", owner.toString());
+
+				int securityChannel = context.getSecurityChannel();
+				if (securityChannel != -1) out.put("securityChannel", securityChannel);
 			}
 
 			out.put("infusion", context.getInfused());
@@ -51,6 +68,51 @@ public final class IntegrationMcJtyLib {
 
 			return tile;
 		}
+	};
+
+	//Based on the code in `mcjty.lib.blocks.GenericBlock.intAddInformation`
+	public static final IMetaProvider<ItemStack> META_GENERIC_ITEM_BLOCK = new ItemStackMetaProvider<GenericItemBlock>(
+		GenericItemBlock.class
+	) {
+		@Nonnull
+		@Override
+		public Map<String, ?> getMeta(@Nonnull ItemStack stack, @Nonnull GenericItemBlock item) {
+			NBTTagCompound nbt = stack.getTagCompound();
+			if (nbt == null) return Collections.emptyMap();
+
+			Map<String, Object> out = new HashMap<>(6);
+
+			if (GeneralConfig.manageOwnership) {
+				//TODO Do we want to expose the UUID, if set, regardless of the owner's name?
+				// That is, how closely do we want to mimic the results of `mcjty.lib.tileentity.GenericBlock.intAddInformation`
+				if (nbt.hasKey("owner", Constants.NBT.TAG_STRING)) out.put("ownerName", nbt.getString("owner"));
+
+				if (nbt.hasKey("idM", Constants.NBT.TAG_LONG) && nbt.hasKey("idL", Constants.NBT.TAG_LONG)) {
+					UUID owner = new UUID(nbt.getLong("idM"), nbt.getLong("idL"));
+					out.put("ownerUUID", owner.toString());
+				}
+
+				if (nbt.hasKey("secChannel", Constants.NBT.TAG_INT)) {
+					int securityChannel = nbt.getInteger("secChannel");
+					if (securityChannel != -1) out.put("securityChannel", securityChannel);
+				}
+			}
+
+			if (nbt.hasKey("Energy", Constants.NBT.TAG_LONG)) out.put("energy", nbt.getLong("Energy"));
+
+			//Unfortunately, `mcjty.lib.blocks.GenericItemBlock` doesn't expose the base Block,
+			// so we can't call `isInfusable`; this results in the 'infusion level' showing on ItemBlocks
+			// that can't be infused...
+			if (nbt.hasKey("infused", Constants.NBT.TAG_INT)) out.put("infusion", nbt.getInteger("infusion"));
+
+			//REFINE See task in META_GENERIC_TILE
+			out.put("infusionMax", GeneralConfig.maxInfuse);
+
+			return out;
+		}
+
+		//TODO Determine if we can implement `getExample` without having to set the Block and Tile
+		// Preferably without manually constructing the NBT...
 	};
 
 }

--- a/src/main/java/org/squiddev/plethora/integration/mcjtylib/IntegrationMcJtyLib.java
+++ b/src/main/java/org/squiddev/plethora/integration/mcjtylib/IntegrationMcJtyLib.java
@@ -1,0 +1,56 @@
+package org.squiddev.plethora.integration.mcjtylib;
+
+import mcjty.lib.McJtyLib;
+import mcjty.lib.base.GeneralConfig;
+import mcjty.lib.tileentity.GenericTileEntity;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.meta.BasicMetaProvider;
+import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.utils.EntityPlayerDummy;
+import org.squiddev.plethora.utils.WorldDummy;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Injects(McJtyLib.PROVIDES)
+public final class IntegrationMcJtyLib {
+	private IntegrationMcJtyLib() {
+	}
+
+	public static final IMetaProvider<GenericTileEntity> META_GENERIC_TILE = new BasicMetaProvider<GenericTileEntity>() {
+
+		@Nonnull
+		@Override
+		public Map<String, ?> getMeta(@Nonnull GenericTileEntity context) {
+			Map<String, Object> out = new HashMap<>(4);
+
+			if (!GeneralConfig.manageOwnership) {
+				out.put("ownerName", context.getOwnerName());
+
+				UUID owner = context.getOwnerUUID();
+				if (owner != null) out.put("ownerUUID", owner.toString());
+			}
+
+			out.put("infusion", context.getInfused());
+
+			//REFINE Do we want to provide the max infusion on each `GenericTileEntity`,
+			// provide it via a method, or provide `getInfusedFactor` as a percentage?
+			out.put("infusionMax", GeneralConfig.maxInfuse);
+
+			return out;
+		}
+
+		@Nonnull
+		@Override
+		public GenericTileEntity getExample() {
+			GenericTileEntity tile = new GenericTileEntity();
+			tile.setInfused(5);
+			tile.setOwner(new EntityPlayerDummy(WorldDummy.INSTANCE));
+
+			return tile;
+		}
+	};
+
+}

--- a/src/main/java/org/squiddev/plethora/integration/rftools/IntegrationRFTools.java
+++ b/src/main/java/org/squiddev/plethora/integration/rftools/IntegrationRFTools.java
@@ -19,8 +19,7 @@ public final class IntegrationRFTools {
 	 *
 	 *
 	 *Dimensions
-	 * We could use IMC to get the Dimension Manager, a la `rftools.setup.ModSetup`,
-	 * reference RFTools' field, or just instantiate it ourselves (less flexible...)
+	 * Use IMC to get the Dimension Manager, a la `rftools.setup.ModSetup`
 	 *
 	 *
 	 *

--- a/src/main/java/org/squiddev/plethora/integration/rftools/IntegrationRFTools.java
+++ b/src/main/java/org/squiddev/plethora/integration/rftools/IntegrationRFTools.java
@@ -9,4 +9,21 @@ public final class IntegrationRFTools {
 	}
 
 
+	/*
+	 *RFTools
+	 *
+	 *
+	 *
+	 *Control
+	 *
+	 *
+	 *
+	 *Dimensions
+	 * We could use IMC to get the Dimension Manager, a la `rftools.setup.ModSetup`,
+	 * reference RFTools' field, or just instantiate it ourselves (less flexible...)
+	 *
+	 *
+	 *
+	 */
+
 }

--- a/src/main/java/org/squiddev/plethora/integration/rftools/IntegrationRFTools.java
+++ b/src/main/java/org/squiddev/plethora/integration/rftools/IntegrationRFTools.java
@@ -1,0 +1,12 @@
+package org.squiddev.plethora.integration.rftools;
+
+import mcjty.rftools.RFTools;
+import org.squiddev.plethora.api.Injects;
+
+@Injects(RFTools.MODID)
+public final class IntegrationRFTools {
+	private IntegrationRFTools() {
+	}
+
+
+}

--- a/src/main/java/org/squiddev/plethora/integration/xnet/IntegrationXNet.java
+++ b/src/main/java/org/squiddev/plethora/integration/xnet/IntegrationXNet.java
@@ -1,0 +1,111 @@
+package org.squiddev.plethora.integration.xnet;
+
+import mcjty.xnet.blocks.cables.ConnectorTileEntity;
+import mcjty.xnet.blocks.facade.FacadeItemBlock;
+import mcjty.xnet.blocks.facade.IFacadeSupport;
+import mcjty.xnet.init.ModBlocks;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import org.squiddev.plethora.api.meta.BaseMetaProvider;
+import org.squiddev.plethora.api.meta.BasicMetaProvider;
+import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.api.meta.ItemStackContextMetaProvider;
+import org.squiddev.plethora.api.method.IPartialContext;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class IntegrationXNet {
+	private IntegrationXNet() {
+	}
+
+	/*
+	 *XNet
+	 * Replicate the 'OC XNet Driver' behavior
+	 * TODO Research how to use 'routing'; hard to provide meta for something you don't know yourself...
+	 * TODO Determine how to expose the mimicked block for an IFacadeSupport
+	 *
+	 */
+
+	/*
+	 * Redstone Proxy - Not sure if this is of interest, as we have our own RS support
+	 * Connector
+	 *   Confirm that the energy capability is properly exposed (or if it should be...)
+	 * Controller
+	 * Router
+	 * Wireless Router
+	 */
+
+	public static final IMetaProvider<IFacadeSupport> META_FACADE = new BaseMetaProvider<IFacadeSupport>() {
+		@Nonnull
+		@Override
+		public Map<String, ?> getMeta(@Nonnull IPartialContext<IFacadeSupport> context) {
+			IFacadeSupport target = context.getTarget();
+			IBlockState mimicState = target.getMimicBlock();
+
+			//TODO As an alternative to this, the mimicked block is also exposed as part of the
+			// IExtendedBlockState; see mcjty.xnet.blocks.cables.ConnectorBlock.getExtendedState
+			// and mcjty.xnet.blocks.facade.FacadeBlock.getExtendedState
+
+			//REFINE This has one minor edge case: new facades default to cobblestone,
+			// BUT the mimicState isn't set until the facade is broken!
+			return mimicState == null
+				? Collections.emptyMap()
+				: Collections.singletonMap("mimicState", context.makePartialChild(mimicState).getMeta());
+		}
+	};
+
+	public static final IMetaProvider<ItemStack> META_FACADE_ITEM = new ItemStackContextMetaProvider<FacadeItemBlock>(
+		FacadeItemBlock.class
+	) {
+		@Nonnull
+		@Override
+		public Map<String, ?> getMeta(@Nonnull IPartialContext<ItemStack> context, @Nonnull FacadeItemBlock item) {
+			//REFINE Technically, we should check if the mimicked block is set (versus using the default)...
+			// See the behavior in mcjty.xnet.blocks.facade.FacadeItemBlock.getMimicBlock
+			return Collections.singletonMap("mimicState", context.makePartialChild(FacadeItemBlock.getMimicBlock(context.getTarget())));
+		}
+
+		@Nonnull
+		@Override
+		public ItemStack getExample() {
+			return new ItemStack(ModBlocks.facadeBlock);
+		}
+	};
+
+	public static final IMetaProvider<ConnectorTileEntity> META_CONNECTOR= new BasicMetaProvider<ConnectorTileEntity>() {
+
+		@Nonnull
+		@Override
+		public Map<String, ?> getMeta(@Nonnull ConnectorTileEntity context) {
+			Map<String, Object> out = new HashMap<>();
+
+			Map<String, Boolean> enabledMap = new HashMap<>(EnumFacing.VALUES.length);
+			for (EnumFacing facing : EnumFacing.VALUES) {
+				enabledMap.put(facing.toString(), context.isEnabled(facing));
+			}
+			out.put("isEnabled", enabledMap);
+
+			out.put("connectorName", context.getConnectorName());
+
+			return out;
+		}
+
+		@Nonnull
+		@Override
+		public ConnectorTileEntity getExample() {
+			ConnectorTileEntity tile = new ConnectorTileEntity();
+
+			tile.setConnectorName("Simple Example");
+			//MEMO The tile's `enabled` mask defaults to 0x3f, or all enabled
+			tile.setEnabled(EnumFacing.DOWN, false);
+			tile.setEnabled(EnumFacing.SOUTH, false);
+
+			return tile;
+		}
+	};
+}

--- a/src/main/java/org/squiddev/plethora/integration/xnet/IntegrationXNet.java
+++ b/src/main/java/org/squiddev/plethora/integration/xnet/IntegrationXNet.java
@@ -1,5 +1,6 @@
 package org.squiddev.plethora.integration.xnet;
 
+import mcjty.xnet.XNet;
 import mcjty.xnet.blocks.cables.ConnectorTileEntity;
 import mcjty.xnet.blocks.facade.FacadeItemBlock;
 import mcjty.xnet.blocks.facade.IFacadeSupport;
@@ -7,17 +8,22 @@ import mcjty.xnet.init.ModBlocks;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import org.squiddev.plethora.api.Injects;
 import org.squiddev.plethora.api.meta.BaseMetaProvider;
 import org.squiddev.plethora.api.meta.BasicMetaProvider;
 import org.squiddev.plethora.api.meta.IMetaProvider;
 import org.squiddev.plethora.api.meta.ItemStackContextMetaProvider;
 import org.squiddev.plethora.api.method.IPartialContext;
+import org.squiddev.plethora.api.method.wrapper.ArgumentType;
+import org.squiddev.plethora.gameplay.modules.glasses.methods.ArgumentPointHelper;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@Injects(XNet.MODID)
 public final class IntegrationXNet {
 	private IntegrationXNet() {
 	}
@@ -38,6 +44,10 @@ public final class IntegrationXNet {
 	 * Router
 	 * Wireless Router
 	 */
+
+	//TODO Determine a better location for this ArgumentType
+	//REFINE This may not be the most efficient, but it does reduce code duplication...
+	public static final ArgumentType<BlockPos> BLOCK_POS = ArgumentPointHelper.VEC3D.map(BlockPos::new);
 
 	public static final IMetaProvider<IFacadeSupport> META_FACADE = new BaseMetaProvider<IFacadeSupport>() {
 		@Nonnull

--- a/src/main/java/org/squiddev/plethora/integration/xnet/IntegrationXNet.java
+++ b/src/main/java/org/squiddev/plethora/integration/xnet/IntegrationXNet.java
@@ -14,7 +14,6 @@ import org.squiddev.plethora.api.meta.ItemStackContextMetaProvider;
 import org.squiddev.plethora.api.method.IPartialContext;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/org/squiddev/plethora/integration/xnet/MethodsController.java
+++ b/src/main/java/org/squiddev/plethora/integration/xnet/MethodsController.java
@@ -1,28 +1,44 @@
 package org.squiddev.plethora.integration.xnet;
 
 
+import dan200.computercraft.api.lua.LuaException;
 import mcjty.xnet.XNet;
 import mcjty.xnet.api.channels.IControllerContext;
 import mcjty.xnet.api.keys.SidedPos;
 import mcjty.xnet.blocks.cables.ConnectorTileEntity;
 import mcjty.xnet.blocks.controller.TileEntityController;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 import org.squiddev.plethora.api.IWorldLocation;
 import org.squiddev.plethora.api.method.ContextKeys;
 import org.squiddev.plethora.api.method.IContext;
 import org.squiddev.plethora.api.method.LuaList;
 import org.squiddev.plethora.api.method.wrapper.FromContext;
 import org.squiddev.plethora.api.method.wrapper.FromTarget;
+import org.squiddev.plethora.api.method.wrapper.Optional;
 import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
 import org.squiddev.plethora.integration.vanilla.meta.MetaBlock;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 // Based heavily off of the OC XNet Driver mod https://minecraft.curseforge.com/projects/oc-xnet-driver
@@ -59,12 +75,23 @@ public final class MethodsController {
 	 *   we could theoretically expose a
 	 */
 
+	/*
+	 *TODO Can we convert this to use existing item/fluid/energy handler code?
+	 * A decent portion of this class focuses on listing the items/fluids/energy exposed by tiles,
+	 * and transferring such to other tiles...
+	 *
+	 *REFINE Extract the LuaException constructors into helper methods, since the same phrases are re-used
+	 *
+	 *TODO The capability checks do not account for the ability of Advanced Connectors to perform sneaky sidedness...
+	 */
 
-	//----------
-	//Start OC XNet Driver stubs
-	//----------
-	// This block is intended to simplify adapting the code from the OC XNet Driver mod,
-	// and may be removed at a later time.
+	/*
+	 *----------
+	 *Start OC XNet Driver stubs
+	 *----------
+	 *This block is intended to simplify adapting the code from the OC XNet Driver mod,
+	 *and may be removed at a later time.
+	 */
 
 	/**
 	 * Converts the internal absolute coords into user-facing relative coords
@@ -78,12 +105,12 @@ public final class MethodsController {
 	 * Converts the user's input relative coords into internal absolute coords
 	 */
 	@Nonnull
-	private static BlockPos toAbsolute(@Nonnull BlockPos pos, BlockPos controllerPos) {
+	private static BlockPos toAbsolute(@Nonnull BlockPos pos, @Nonnull BlockPos controllerPos) {
 		return pos.add(controllerPos);
 	}
 
 	@Nullable
-	private static SidedPos getSidedPos(BlockPos pos, @Nonnull IControllerContext context) {
+	private static SidedPos getSidedPos(@Nonnull BlockPos pos, @Nonnull IControllerContext context) {
 		return context.getConnectedBlockPositions().stream()
 			.filter(sp -> sp.getPos().equals(pos)).findFirst()
 			.orElse(null);
@@ -99,8 +126,8 @@ public final class MethodsController {
 		modId = XNet.MODID,
 		doc = "-- List all blocks connected to the XNet network"
 	)
-	public static Map<Integer, Object> getConnectedBlocks(@FromTarget TileEntityController controller,
-														  @FromContext(ContextKeys.ORIGIN) IWorldLocation location) {
+	public static Map<Integer, Object> getConnectedBlocks(@Nonnull @FromTarget TileEntityController controller,
+														  @Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location) {
 		LuaList<Object> out = new LuaList<>();
 		World world = location.getWorld();
 		BlockPos controllerPos = location.getPos();
@@ -130,7 +157,8 @@ public final class MethodsController {
 
 	// Extracted to try and find a cleaner structure; not much luck, as I end up with either
 	// nested if statements, or multiple returns...
-	private static String getConnectorName(World world, BlockPos connectorPos) {
+	@Nullable
+	private static String getConnectorName(@Nonnull World world, @Nonnull BlockPos connectorPos) {
 		ResourceLocation resourceLocation = world.getBlockState(connectorPos).getBlock().getRegistryName();
 		if (resourceLocation == null) {
 			return null;
@@ -154,17 +182,417 @@ public final class MethodsController {
 	}
 
 
+	@Nullable
 	@PlethoraMethod(
 		modId = XNet.MODID,
-		doc = "-- FIXME Describe the method"
+		doc = "-- List all capability of the given block at the given or connected side"
 	)
-	public static Map<String, ?> getSupportedCapabilities(@Nonnull IContext<TileEntityController> context) {
+	public static Map<Integer, String> getSupportedCapabilities(@Nonnull @FromTarget TileEntityController controller,
+																@Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+																@Nonnull BlockPos posArg,
+																@Optional EnumFacing sideArg) throws LuaException {
+		//REFINE Yes, the BlockPos and EnumFacing args need better names...
+		BlockPos pos = toAbsolute(posArg, location.getPos());
+
+		SidedPos sidedPos = getSidedPos(pos, controller);
+		if (sidedPos == null) throw badPosition();
+
+		EnumFacing side = (sideArg != null) ? sideArg : sidedPos.getSide();
+
+		TileEntity tile = location.getWorld().getTileEntity(pos);
+		if (tile == null) throw nonTile();
+
+		LuaList<String> out = new LuaList<>(3);
+
+		if (tile.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side)) out.add("items");
+		if (tile.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side)) out.add("fluid");
+		if (tile.hasCapability(CapabilityEnergy.ENERGY, side)) out.add("energy");
+
+		return out.asMap();
+	}
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- List all items in the given inventory"
+	)
+	public static Map<String, ?> getItems(@Nonnull @FromTarget TileEntityController controller,
+										  @Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+										  @Nonnull BlockPos posArg,
+										  @Optional EnumFacing sideArg) throws LuaException {
+		BlockPos pos = toAbsolute(posArg, location.getPos());
+
+		SidedPos sidedPos = getSidedPos(pos, controller);
+		if (sidedPos == null) throw badPosition();
+
+		EnumFacing side = (sideArg != null) ? sideArg : sidedPos.getSide();
+
+		TileEntity tile = location.getWorld().getTileEntity(pos);
+		if (tile == null) throw nonTile();
+
+		if (!tile.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side)) throw nonItemHandler();
+
+		IItemHandler handler = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
+		List<ItemStack> result = new ArrayList<>();
+		for (int slot = 0; slot < handler.getSlots(); slot++) {
+			ItemStack stack = handler.getStackInSlot(slot);
+			result.add(stack.copy());
+		}
+
+		//FIXME set the actual return
+		// OC XNet driver wrapped the `result` list in an Object array, but CC doesn't have a native ItemStack type,
+		// and Plethora already handles listing items in an inventory...
+
+		return null;
+	}
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- Transfer items between two inventories"
+	)
+	public static int transferItem(@Nonnull @FromTarget TileEntityController controller,
+								   @Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+								   @Nonnull BlockPos sourcePosArg,
+								   int sourceSlot,
+								   int amount,
+								   @Nonnull BlockPos targetPosArg,
+								   @Optional EnumFacing sourceSideArg,
+								   @Optional EnumFacing targetSideArg) throws LuaException {
+		BlockPos pos = toAbsolute(sourcePosArg, location.getPos());
+
+		SidedPos sidedPos = getSidedPos(pos, controller);
+		if(sidedPos == null) throw badPosition("source");
+
+		EnumFacing side = (sourceSideArg != null) ? sourceSideArg : sidedPos.getSide();
+
+		TileEntity tileEntity = location.getWorld().getTileEntity(pos);
+		if(tileEntity == null) throw nonTile("source");
+
+		if(!tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side)) {
+			throw nonItemHandler("source");
+		}
+
+		BlockPos targetPos = toAbsolute(targetPosArg, location.getPos());
+
+		SidedPos targetSidedPos = getSidedPos(targetPos, controller);
+		if(targetSidedPos == null) throw badPosition("target");
+
+		EnumFacing targetSide = (targetSideArg != null) ? targetSideArg : targetSidedPos.getSide();
+
+		TileEntity targetTileEntity = location.getWorld().getTileEntity(targetPos);
+		if(targetTileEntity == null) throw nonTile("target");
+
+		if(!targetTileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, targetSide)) {
+			throw nonItemHandler("target");
+		}
+
+		IItemHandler handler = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
+		IItemHandler targetHandler = targetTileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, targetSide);
+
+
+		//`handler` should be nonnull, as we already checked if the tile had the capability;
+		// only edge case would be someone modifying the tile mid-tick...
+		//noinspection ConstantConditions
+		ItemStack sourceStackSim = handler.extractItem(sourceSlot-1, amount, true);
+		if(sourceStackSim.isEmpty()) throw new LuaException("can not extract from source slot");
+
+		ItemStack returnStackSim = ItemHandlerHelper.insertItemStacked(targetHandler, sourceStackSim, true);
+
+		int transferableAmount = returnStackSim.isEmpty() ? amount : sourceStackSim.getCount() - returnStackSim.getCount();
+
+		if (transferableAmount <= 0) throw new LuaException("can not insert into target");
+
+		ItemStack sourceStackReal = handler.extractItem(sourceSlot - 1, transferableAmount, false);
+		ItemHandlerHelper.insertItemStacked(targetHandler, sourceStackReal, false);
+
+		return transferableAmount;
+	}
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- List all fluids in the given tank"
+	)
+	public static Map<Integer, ?> getFluids(@Nonnull @FromTarget TileEntityController controller,
+											@Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+											@Nonnull BlockPos posArg,
+											@Optional EnumFacing sideArg) throws LuaException {
+		BlockPos pos = toAbsolute(posArg, location.getPos());
+
+		SidedPos sidedPos = getSidedPos(pos, controller);
+		if(sidedPos == null) throw badPosition();
+
+		EnumFacing side = (sideArg != null) ? sideArg : sidedPos.getSide();
+
+		TileEntity tileEntity = location.getWorld().getTileEntity(pos);
+		if(tileEntity == null) throw nonTile();
+
+		if(!tileEntity.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side)) {
+			throw nonFluidHandler();
+		}
+
+		IFluidHandler handler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+
+		LuaList<Object> result = new LuaList<>();
+		for(IFluidTankProperties tank : handler.getTankProperties()) {
+			HashMap<String, Object> map = new HashMap<>();
+			map.put("capacity", tank.getCapacity());
+			map.put("content", tank.getContents());
+			result.add(map);
+		}
+
+		return result.asMap();
+	}
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- Transfer fluids between two tanks"
+	)
+	public static int transferFluid(@Nonnull IContext<TileEntityController> context,
+									@Nonnull @FromTarget TileEntityController controller,
+									@Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+									@Nonnull BlockPos sourcePosArg,
+									int amount,
+									@Nonnull BlockPos targetPosArg,
+									@Optional String fluidName,
+									@Optional EnumFacing sourceSideArg,
+									@Optional EnumFacing targetSideArg) throws LuaException {
+		//MEMO Check if you need the full `IContext` or can make due with `@FromTarget`
+		BlockPos pos = toAbsolute(sourcePosArg, location.getPos());
+
+		SidedPos sidedPos = getSidedPos(pos, controller);
+		if(sidedPos == null) throw badPosition("source");
+
+		EnumFacing side = (sourceSideArg != null) ? sourceSideArg : sidedPos.getSide();
+
+		TileEntity tileEntity = location.getWorld().getTileEntity(pos);
+		if(tileEntity == null) throw nonTile("source");
+
+		if(!tileEntity.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side)) {
+			throw nonFluidHandler("source");
+		}
+
+		BlockPos targetPos = toAbsolute(targetPosArg, location.getPos());
+
+		SidedPos targetSidedPos = getSidedPos(targetPos, controller);
+		if(targetSidedPos == null) throw badPosition("target");
+
+		EnumFacing targetSide = (targetSideArg != null) ? targetSideArg : targetSidedPos.getSide();
+
+		TileEntity targetTileEntity = location.getWorld().getTileEntity(targetPos);
+		if(targetTileEntity == null) throw nonTile("target");
+
+		if(!targetTileEntity.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, targetSide)) {
+			throw nonFluidHandler("target");
+		}
+
+		FluidStack extractStack = null;
+		if(fluidName != null) {
+			extractStack = FluidRegistry.getFluidStack(fluidName, amount);
+			if(extractStack == null) {
+				throw new LuaException("Unkown fluid: " + fluidName);
+			}
+		}
+
+		IFluidHandler handler = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
+		IFluidHandler targetHandler = targetTileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, targetSide);
+
+		FluidStack simStack;
+		if(extractStack != null) {
+			simStack = handler.drain(extractStack, false);
+		} else {
+			simStack = handler.drain(amount, false);
+		}
+
+		if(simStack == null) {
+			throw new LuaException("can not drain from source tank");
+		}
+
+		int simAmount = targetHandler.fill(simStack, false);
+		if(simAmount <= 0) {
+			throw new LuaException("can not fill target tank");
+		}
+
+		FluidStack realStack;
+		if(extractStack != null) {
+			extractStack.amount = simAmount;
+			realStack = handler.drain(extractStack, true);
+		} else {
+			realStack = handler.drain(simAmount, true);
+		}
+
+		targetHandler.fill(realStack, true);
+
+		return simAmount;
+	}
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- function(pos:table[, side: number]):table -- Get capacity and stored energy of the given energy handler"
+	)
+	public static Map<String, ?> getEnergy(@Nonnull IContext<TileEntityController> context,
+										   @Nonnull @FromTarget TileEntityController controller,
+										   @Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+										   @Nonnull BlockPos posArg,
+										   @Optional EnumFacing sideArg) throws LuaException {
 		//MEMO Check if you need the full `IContext` or can make due with `@FromTarget`
 
-		//TODO Fill in this code; OC XNet Driver parses the target position and side, gets the TE, then checks for
-		// item, fluid, and energy capabilities.
-		// To expose a similar behavior, I will need to define a custom ArgumentType
+		BlockPos pos = toAbsolute(posArg, location.getPos());
+		SidedPos sidedPos = getSidedPos(pos, controller);
 
-		return null; //FIXME set the actual return
+		if(sidedPos == null) throw badPosition();
+
+		EnumFacing side = (sideArg != null) ? sideArg : sidedPos.getSide(); //TODO Verify correct variables
+
+		TileEntity tileEntity = location.getWorld().getTileEntity(pos);
+		if(tileEntity == null) throw nonTile();
+
+		if(!tileEntity.hasCapability(CapabilityEnergy.ENERGY, side)) {
+			throw nonEnergyHandler();
+		}
+
+		IEnergyStorage handler = tileEntity.getCapability(CapabilityEnergy.ENERGY, side);
+
+		HashMap<String, Object> result = new HashMap<>();
+		result.put("capacity", handler.getMaxEnergyStored());
+		result.put("stored", handler.getEnergyStored());
+		result.put("canExtract", handler.canExtract());
+		result.put("canReceive", handler.canReceive());
+
+		return result;
+	}
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- Transfer energy between two energy handlers"
+	)
+	public static int transferEnergy(@Nonnull IContext<TileEntityController> context,
+												@Nonnull @FromTarget TileEntityController controller,
+												@Nonnull @FromContext(ContextKeys.ORIGIN) IWorldLocation location,
+												@Nonnull BlockPos sourcePosArg,
+												int amount,
+												@Nonnull BlockPos targetPosArg,
+												@Optional EnumFacing sourceSideArg,
+												@Optional EnumFacing targetSideArg) throws LuaException {
+		//MEMO Check if you need the full `IContext` or can make due with `@FromTarget`
+		BlockPos pos = toAbsolute(sourcePosArg, location.getPos());
+
+		SidedPos sidedPos = getSidedPos(pos, controller);
+		if(sidedPos == null) throw badPosition("source");
+
+		EnumFacing side = (sourceSideArg != null) ? sourceSideArg : sidedPos.getSide();
+
+		TileEntity tileEntity = location.getWorld().getTileEntity(pos);
+		if(tileEntity == null) throw nonTile("source");
+
+		if(!tileEntity.hasCapability(CapabilityEnergy.ENERGY, side)) {
+			throw nonEnergyHandler("source");
+		}
+
+		BlockPos targetPos = toAbsolute(targetPosArg, location.getPos());
+		SidedPos targetSidedPos = getSidedPos(targetPos, controller);
+		if(targetSidedPos == null) throw badPosition("target");
+
+		EnumFacing targetSide = (targetSideArg != null) ? targetSideArg : targetSidedPos.getSide();
+
+		TileEntity targetTileEntity = location.getWorld().getTileEntity(targetPos);
+		if(targetTileEntity == null) throw nonTile("target");
+
+		if(!targetTileEntity.hasCapability(CapabilityEnergy.ENERGY, targetSide)) {
+			throw nonEnergyHandler("target");
+		}
+
+		IEnergyStorage handler = tileEntity.getCapability(CapabilityEnergy.ENERGY, side);
+		IEnergyStorage targetHandler = targetTileEntity.getCapability(CapabilityEnergy.ENERGY, targetSide);
+
+		if(!handler.canExtract()) {
+			throw new LuaException("can not extract energy from source");
+		}
+
+		if(!targetHandler.canReceive()) {
+			throw new LuaException("can not insert energy into target");
+		}
+
+		int transferred = 0;
+		int simulatedTicks = 0;
+		List<String> errors = new ArrayList<>();
+		while(transferred < amount && simulatedTicks < 1) {
+			int simAmount = handler.extractEnergy(amount - transferred, true);
+			if(simAmount <= 0) {
+				errors.add("extractable amount from source is 0");
+				break;
+			}
+
+			int simReceived = targetHandler.receiveEnergy(simAmount, true);
+			if(simReceived <= 0) {
+				errors.add("insertable amount into target is 0");
+				break;
+			}
+
+			simulatedTicks++;
+			handler.extractEnergy(simReceived, false);
+			targetHandler.receiveEnergy(simReceived, false);
+
+			transferred += simReceived;
+		}
+
+		//return new Object[]{ transferred, errors };
+		return transferred; //FIXME set the actual return
+	}
+
+	@Nonnull
+	private static LuaException badPosition() {
+		return badPosition("");
+	}
+
+	@Nonnull
+	private static LuaException badPosition(@Nonnull String description) {
+		//REFINE Is there a better way to handle the appending a space for non-empty strings?
+		String descriptionPadded = !description.isEmpty() ? description + " " : "";
+		return new LuaException("Given " + descriptionPadded + "position is not connected to the network");
+	}
+
+	@Nonnull
+	private static LuaException nonTile() {
+		//REFINE Does this exception even make sense?
+		// I mean, if a block is connected to the network, shouldn't it be a TE?
+		return nonTile("");
+	}
+
+	@Nonnull
+	private static LuaException nonTile(@Nonnull String description) {
+		String descriptionPlus = !description.isEmpty() ? " - " + description : "";
+		return new LuaException("Not a tile entity" + descriptionPlus);
+	}
+
+	@Nonnull
+	private static LuaException nonItemHandler() {
+		return nonItemHandler("");
+	}
+
+	@Nonnull
+	private static LuaException nonItemHandler(@Nonnull String description) {
+		String descriptionPlus = !description.isEmpty() ? " - " + description : "";
+		return new LuaException("Not an item handler" + descriptionPlus);
+	}
+
+	@Nonnull
+	private static LuaException nonFluidHandler() {
+		return nonFluidHandler("");
+	}
+
+	@Nonnull
+	private static LuaException nonFluidHandler(@Nonnull String description) {
+		String descriptionPlus = !description.isEmpty() ? " - " + description : "";
+		return new LuaException("Not a fluid handler" + descriptionPlus);
+	}
+
+	@Nonnull
+	private static LuaException nonEnergyHandler() {
+		return nonEnergyHandler("");
+	}
+
+	@Nonnull
+	private static LuaException nonEnergyHandler(@Nonnull String description) {
+		String descriptionPlus = !description.isEmpty() ? " - " + description : "";
+		return new LuaException("Not an energy handler" + descriptionPlus);
 	}
 }

--- a/src/main/java/org/squiddev/plethora/integration/xnet/MethodsController.java
+++ b/src/main/java/org/squiddev/plethora/integration/xnet/MethodsController.java
@@ -1,0 +1,152 @@
+package org.squiddev.plethora.integration.xnet;
+
+
+import mcjty.xnet.XNet;
+import mcjty.xnet.api.channels.IControllerContext;
+import mcjty.xnet.api.keys.SidedPos;
+import mcjty.xnet.blocks.cables.ConnectorTileEntity;
+import mcjty.xnet.blocks.controller.TileEntityController;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.method.ContextKeys;
+import org.squiddev.plethora.api.method.IContext;
+import org.squiddev.plethora.api.method.LuaList;
+import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+// Based heavily off of the OC XNet Driver mod https://minecraft.curseforge.com/projects/oc-xnet-driver
+public final class MethodsController {
+	private MethodsController() {
+	}
+
+	/*
+	 *Links for convenience in pulling up references:
+	 * https://raw.githubusercontent.com/thraaawn/OCXNetDriver/master/src/main/java/org/dave/ocxnetdriver/driver/controller/EnvironmentXnetController.java
+	 * https://github.com/thraaawn/OCXNetDriver/raw/master/src/main/java/org/dave/ocxnetdriver/converter/ConverterBlockPos.java
+	 *
+	 */
+
+	/*
+	 *Methods defined in the OC XNet Driver:
+	 * getConnectedBlocks
+	 * getSupportedCapabilities(pos[, side])
+	 * getItems(pos[, side])
+	 * getFluids(pos[, side])
+	 * getEnergy(pos[, side])
+	 * transferItem(sourcePos, sourceSlot, amount, targetPos[, sourceSide[, targetSide]])
+	 * transferFluids(sourcePos, amount, targetPos[, fluidName][, sourceSide[, targetSide]])
+	 * transferEnergy(sourcePos, amount, targetPos[, sourceSide[, targetSide]])
+	 * store(sourcePos, sourceSlot, database, entry[, sourceSide]) - Stores an itemstack in an OC database upgrade
+	 *
+	 *Additional data that we may expose, either method or meta
+	 * NetworkId
+	 * Channels
+	 * RF storage - should already be exposed
+	 * Logic state - the colors are defined in mcjty.xnet.api.channels.Color,
+	 *   usage shown in mcjty.xnet.api.helper.AbstractConnectorSettings.calculateColorsMask
+	 *   Alternatively, a player could set a Redstone Proxy and read the state;
+	 *   we could theoretically expose a
+	 */
+
+
+	//----------
+	//Start OC XNet Driver stubs
+	//----------
+	// This block is intended to simplify adapting the code from the OC XNet Driver mod,
+	// and may be removed at a later time.
+
+	//TODO Do we need this?  This was a configuration setting in OC XNet Driver
+	private static final boolean relativePositions = false;
+
+	//TODO File an issue with OC XNet Driver; they had the same check for `toRelative` and `toAbsolute`
+	private static BlockPos toRelative(BlockPos pos, BlockPos controllerPos) {
+		return relativePositions
+			? pos
+			: pos.add(-controllerPos.getX(), -controllerPos.getY(), -controllerPos.getZ());
+	}
+
+	private static BlockPos toAbsolute(BlockPos pos, BlockPos controllerPos) {
+		return !relativePositions
+			? pos
+			: pos.add(controllerPos.getX(), controllerPos.getY(), controllerPos.getZ());
+	}
+
+	@Nullable
+	private static SidedPos getSidedPos(BlockPos pos, @Nonnull IControllerContext context) {
+		return context.getConnectedBlockPositions().stream()
+			.filter(sp -> sp.getPos().equals(pos)).findFirst()
+			.orElse(null);
+	}
+
+	//----------
+	//End OC XNet Driver stubs
+	//----------
+
+	//TODO Check if this (and the other methods in this class)
+	// can use IControllerContext instead of TileEntityController
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- List all blocks connected to the XNet network"
+	)
+	public static Map<Integer, Object> getConnectedBlocks(@Nonnull IContext<TileEntityController> context) {
+		//REFINE Do we want to return a Tuple<boolean, ?> representing the success and result/error?
+		LuaList<Object> out = new LuaList<>();
+		TileEntityController controller = context.getTarget();
+
+		IWorldLocation location = context.getContext(ContextKeys.ORIGIN, IWorldLocation.class);
+		if (location == null) return Collections.emptyMap(); //REFINE Do I need to return an empty map for a method?
+
+		World world = location.getWorld();
+		BlockPos controllerPos = location.getPos();
+
+		for(SidedPos pos : controller.getConnectedBlockPositions()) {
+			Map<String, Object> inner = new HashMap<>();
+			IBlockState state = world.getBlockState(pos.getPos());
+
+			//REFINE Some of this could probably be exposed using our existing meta providers
+			inner.put("pos", toRelative(pos.getPos(), controllerPos));
+			inner.put("side", pos.getSide());
+			inner.put("name", state.getBlock().getRegistryName());
+			inner.put("meta", state.getBlock().getMetaFromState(state));
+
+			BlockPos connectorPos = pos.getPos().offset(pos.getSide());
+
+			String registryName = world.getBlockState(connectorPos).getBlock().getRegistryName().toString();
+			if(registryName.equals("xnet:advanced_connector") || registryName.equals("xnet:connector")) {
+				//TODO File issue with OC XNet Driver; they had used reflection here, rather than just using the methods...
+				TileEntity tile = world.getTileEntity(connectorPos);
+				if (tile instanceof ConnectorTileEntity) {
+					ConnectorTileEntity connectorTile = (ConnectorTileEntity) tile;
+					String connectorName = connectorTile.getConnectorName();
+					if (connectorName != null && !connectorName.isEmpty()) inner.put("connector", connectorName);
+				}
+			}
+			out.add(inner);
+		}
+
+		return out.asMap();
+	}
+
+
+	@PlethoraMethod(
+		modId = XNet.MODID,
+		doc = "-- FIXME Describe the method"
+	)
+	public static Map<String, ?> getSupportedCapabilities(@Nonnull IContext<TileEntityController> context) {
+		//MEMO Check if you need the full `IContext` or can make due with `@FromTarget`
+
+		//TODO Fill in this code; OC XNet Driver parses the target position and side, gets the TE, then checks for
+		// item, fluid, and energy capabilities.
+		// To expose a similar behavior, I will need to define a custom ArgumentType
+
+		return null; //FIXME set the actual return
+	}
+}


### PR DESCRIPTION
See issue #158 

While hardly ready for a proper PR, I definitely need some input on the design.  Starting with a bit of base shared functionality (owner and infusion level, provided by McJtyLib), I set up a test world and grouped items by each (sub)mod.  I'm starting with XNet, as it has the fewest blocks/items/entities to support.

I'm not sure if the dependencies being `deobfCompile` is necessary; I was having trouble loading my test instance, and some of McJty's code references the obfuscated names (turned out that I needed to bump the version of RFTools Control).