### PR TITLE
Fixes #215, #162, look pitch, allows enabling of AI #19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ repositories {
 
 	maven { url 'http://chickenbones.net/maven/' } // CBMP
 	maven { url 'http://dvs1.progwml6.com/files/maven/' } // JEI + Tinker's
+	maven { url 'http://dyonovan.com/maven2/' } // Industrial Foregoing
 	maven { url 'http://maven.ic2.player.to/' } // IC2 + Forestry
 	maven { url 'https://dl.bintray.com/squiddev/maven/' } // ConfigGen (why do I use this still?)
 	maven { url 'https://maven.amadornes.com/' } // Multipart
@@ -65,6 +66,7 @@ repositories {
 	maven { url 'https://maven.covers1624.net/' } // CoFH
 	maven { url 'https://maven.k-4u.nl/' } // McJty's mods
 	maven { url 'https://maven.mcmoddev.com/' } // Tesla
+	maven { url 'https://maven.shadowfacts.net' } // Forgelin
 	maven { url 'https://maven.tterrag.com/' } // EnderCore
 	maven { url 'https://maven2.tterrag.com/' } // EnderIO
 	maven { url 'https://mod-buildcraft.com/maven/' } // Buildcraft
@@ -89,6 +91,7 @@ dependencies {
 	integrationMod "cofh:ThermalExpansion:1.12.2-5.5.3.41:universal"
 	integrationMod "cofh:ThermalFoundation:1.12.2-2.6.2.26:universal"
 	integrationMod "cofh:CoFHWorld:1.12.2-1.3.0.6:universal"
+	integrationMod("com.buuz135.industrial.IndustrialForegoing:industrialforegoing:1.12.2-1.5.13-136") { exclude group: "mezz.jei" }
 	compileOnly   ("com.enderio:EnderIO:1.12.2-5.0.43") { transitive = false }
 	compileOnly    "com.enderio.core:EnderCore:1.12.2-0.5.57" // EnderCore appears to crash in a development environment.
 	integrationMod("com.github.mcjty:mcjtylib:1.12-3.5.0") { transitive = false }
@@ -105,6 +108,7 @@ dependencies {
 	integrationMod "slimeknights:TConstruct:1.12.2-2.12.0.116"
 	integrationMod "slimeknights.mantle:Mantle:1.12-1.3.3.51"
 	integrationMod "vazkii.botania:Botania:r1.10-362.77"
+	integrationMod "net.ndrei:tesla-core-lib:1.12.2-1.0.15.16:deobf"
 
 	// All the Curse mods
 	integrationMod "baubles:Baubles:1.12:1.5.2"
@@ -115,6 +119,9 @@ dependencies {
 	integrationMod "roost:roost:1.12:1.3.0"
 	integrationMod "chickens:chickens:6.0.4"
 	integrationMod "hatchery:hatchery:1.12.2:2.2.1"
+	integrationMod "cyclic:Cyclic:1.12.2:1.19.9"
+	integrationMod "extra-utilities:extrautils2:1.12:1.9.9"
+	integrationMod "not-enough-wands:notenoughwands:1.12:1.8.1"
 
 	compileOnly('org.squiddev:ConfigGen:1.2.5') { exclude group: 'net.minecraftforge' }
 
@@ -172,9 +179,10 @@ curseforge {
 }
 
 task runTestServer(type: JavaExec) {
-  classpath = sourceSets.test.runtimeClasspath
-  main = "org.squiddev.plethora.boostrap.LaunchServer"
-  workingDir = "${project.projectDir}/test-files/server"
+	classpath = sourceSets.test.runtimeClasspath
+	main = "org.squiddev.plethora.boostrap.LaunchServer"
+	workingDir = "${project.projectDir}/test-files/server"
+	systemProperties = ["fml.queryResult": "confirm"]
 
-  workingDir.mkdirs()
+	workingDir.mkdirs()
 }

--- a/src/main/java/org/squiddev/plethora/api/EntityWorldLocation.java
+++ b/src/main/java/org/squiddev/plethora/api/EntityWorldLocation.java
@@ -20,10 +20,6 @@ public class EntityWorldLocation implements ConstantReference<IWorldLocation>, I
 		this.entity = entity;
 	}
 
-	private boolean isEntityLookingDown() {
-		return this.entity.rotationPitch >= 45 && this.entity.rotationPitch <= 90;
-	}
-
 	@Nonnull
 	@Override
 	public World getWorld() {
@@ -33,13 +29,13 @@ public class EntityWorldLocation implements ConstantReference<IWorldLocation>, I
 	@Nonnull
 	@Override
 	public BlockPos getPos() {
-		return new BlockPos(entity.posX, entity.posY + (isEntityLookingDown() ? 0 : entity.getEyeHeight()), entity.posZ);
+		return new BlockPos(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
 	}
 
 	@Nonnull
 	@Override
 	public Vec3d getLoc() {
-		return new Vec3d(entity.posX, entity.posY + (isEntityLookingDown() ? 0 : entity.getEyeHeight()), entity.posZ);
+		return new Vec3d(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/api/EntityWorldLocation.java
+++ b/src/main/java/org/squiddev/plethora/api/EntityWorldLocation.java
@@ -20,6 +20,10 @@ public class EntityWorldLocation implements ConstantReference<IWorldLocation>, I
 		this.entity = entity;
 	}
 
+	private boolean isEntityLookingDown() {
+		return this.entity.rotationPitch >= 45 && this.entity.rotationPitch <= 90;
+	}
+
 	@Nonnull
 	@Override
 	public World getWorld() {
@@ -29,13 +33,13 @@ public class EntityWorldLocation implements ConstantReference<IWorldLocation>, I
 	@Nonnull
 	@Override
 	public BlockPos getPos() {
-		return new BlockPos(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
+		return new BlockPos(entity.posX, entity.posY + (isEntityLookingDown() ? 0 : entity.getEyeHeight()), entity.posZ);
 	}
 
 	@Nonnull
 	@Override
 	public Vec3d getLoc() {
-		return new Vec3d(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
+		return new Vec3d(entity.posX, entity.posY + (isEntityLookingDown() ? 0 : entity.getEyeHeight()), entity.posZ);
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/api/EntityWorldLocation.java
+++ b/src/main/java/org/squiddev/plethora/api/EntityWorldLocation.java
@@ -1,6 +1,7 @@
 package org.squiddev.plethora.api;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -36,6 +37,13 @@ public class EntityWorldLocation implements ConstantReference<IWorldLocation>, I
 	@Override
 	public Vec3d getLoc() {
 		return new Vec3d(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
+	}
+
+	@Nonnull
+	@Override
+	public AxisAlignedBB getBounds() {
+		AxisAlignedBB bounds = entity.getCollisionBoundingBox();
+		return bounds == null ? entity.getEntityBoundingBox() : bounds;
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/api/IWorldLocation.java
+++ b/src/main/java/org/squiddev/plethora/api/IWorldLocation.java
@@ -1,5 +1,6 @@
 package org.squiddev.plethora.api;
 
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -41,4 +42,15 @@ public interface IWorldLocation extends IReference<IWorldLocation> {
 	 */
 	@Nonnull
 	Vec3d getLoc();
+
+	/**
+	 * Get the bounding box of this location.
+	 *
+	 * This represents the entire area this location represents. Both {@link #getPos()} and {@link #getLoc()} should be
+	 * contained within it.
+	 *
+	 * @return This location's bounding box.
+	 */
+	@Nonnull
+	AxisAlignedBB getBounds();
 }

--- a/src/main/java/org/squiddev/plethora/api/TurtleWorldLocation.java
+++ b/src/main/java/org/squiddev/plethora/api/TurtleWorldLocation.java
@@ -1,6 +1,7 @@
 package org.squiddev.plethora.api;
 
 import dan200.computercraft.api.turtle.ITurtleAccess;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -37,6 +38,13 @@ public class TurtleWorldLocation implements ConstantReference<IWorldLocation>, I
 	public Vec3d getLoc() {
 		BlockPos pos = turtle.getPosition();
 		return new Vec3d(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5);
+	}
+
+	@Nonnull
+	@Override
+	public AxisAlignedBB getBounds() {
+		BlockPos pos = turtle.getPosition();
+		return new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/api/WorldLocation.java
+++ b/src/main/java/org/squiddev/plethora/api/WorldLocation.java
@@ -1,5 +1,6 @@
 package org.squiddev.plethora.api;
 
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -18,6 +19,7 @@ public final class WorldLocation implements ConstantReference<IWorldLocation>, I
 	private final World world;
 	private final BlockPos pos;
 	private final Vec3d loc;
+	private AxisAlignedBB bounds;
 
 	public WorldLocation(@Nonnull World world, @Nonnull BlockPos pos) {
 		Objects.requireNonNull(world, "world cannot be null");
@@ -57,6 +59,13 @@ public final class WorldLocation implements ConstantReference<IWorldLocation>, I
 	@Override
 	public Vec3d getLoc() {
 		return loc;
+	}
+
+	@Nonnull
+	@Override
+	public AxisAlignedBB getBounds() {
+		return bounds != null ? bounds
+			: new AxisAlignedBB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
 	}
 
 	@Nonnull

--- a/src/main/java/org/squiddev/plethora/core/PlethoraCore.java
+++ b/src/main/java/org/squiddev/plethora/core/PlethoraCore.java
@@ -3,11 +3,13 @@ package org.squiddev.plethora.core;
 import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import mcjty.xnet.XNet;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
@@ -27,6 +29,7 @@ import org.squiddev.plethora.core.capabilities.*;
 import org.squiddev.plethora.core.executor.TaskRunner;
 import org.squiddev.plethora.core.wrapper.PlethoraMethodRegistry;
 import org.squiddev.plethora.gameplay.Plethora;
+import org.squiddev.plethora.gameplay.PlethoraFakePlayer;
 import org.squiddev.plethora.integration.vanilla.IntegrationVanilla;
 import org.squiddev.plethora.utils.Helpers;
 
@@ -153,5 +156,16 @@ public class PlethoraCore {
 	@SubscribeEvent
 	public static void registerRecipes(RegistryEvent.Register<IRecipe> event) {
 		ModuleRegistry.instance.addRecipes(event.getRegistry());
+	}
+
+	@SubscribeEvent
+	public static void onEntitySpawn(EntityJoinWorldEvent event) {
+		Entity entity = event.getEntity();
+		if (!(entity instanceof PlethoraFakePlayer)) return;
+
+		event.setCanceled(true);
+		event.getWorld().playerEntities.remove(entity);
+
+		LOG.error("Attempted to spawn PlethoraFakePlayer ({}). This should NEVER happen.", new IllegalStateException("Stacktrace as follows:"));
 	}
 }

--- a/src/main/java/org/squiddev/plethora/core/PocketUpgradeModule.java
+++ b/src/main/java/org/squiddev/plethora/core/PocketUpgradeModule.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -272,6 +273,13 @@ class PocketUpgradeModule implements IPocketUpgrade {
 		@Override
 		public Vec3d getLoc() {
 			return lastEntity.getPositionVector();
+		}
+
+		@Nonnull
+		@Override
+		public AxisAlignedBB getBounds() {
+			AxisAlignedBB bounds = lastEntity.getCollisionBoundingBox();
+			return bounds == null ? lastEntity.getEntityBoundingBox() : bounds;
 		}
 
 		@Nonnull

--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/methods/MethodsCanvas3D.java
@@ -18,7 +18,6 @@ import org.squiddev.plethora.gameplay.modules.glasses.objects.object3d.*;
 
 import static dan200.computercraft.core.apis.ArgumentHelper.optInt;
 import static org.squiddev.plethora.api.method.ArgumentHelper.getFloat;
-import static org.squiddev.plethora.api.method.ArgumentHelper.optFloat;
 import static org.squiddev.plethora.gameplay.modules.glasses.objects.Colourable.DEFAULT_COLOUR;
 
 public final class MethodsCanvas3D {

--- a/src/main/java/org/squiddev/plethora/integration/cyclic/IntegrationCyclic.java
+++ b/src/main/java/org/squiddev/plethora/integration/cyclic/IntegrationCyclic.java
@@ -1,0 +1,64 @@
+package org.squiddev.plethora.integration.cyclic;
+
+import com.lothrazar.cyclicmagic.item.mobcapture.ItemProjectileMagicNet;
+import com.lothrazar.cyclicmagic.util.Const;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.passive.EntitySquid;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.integration.ItemEntityStorageMetaProvider;
+import org.squiddev.plethora.utils.WorldDummy;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static com.lothrazar.cyclicmagic.item.mobcapture.ItemProjectileMagicNet.NBT_ENTITYID;
+
+@Injects(Const.MODID)
+public final class IntegrationCyclic {
+	public static final IMetaProvider<ItemStack> META_MONSTER_NET = new ItemEntityStorageMetaProvider<ItemProjectileMagicNet>(
+		"capturedEntity", ItemProjectileMagicNet.class,
+		"Provides the entity captured inside this monster net."
+	) {
+		@Nullable
+		@Override
+		protected Entity spawn(@Nonnull ItemStack stack, @Nonnull ItemProjectileMagicNet item, @Nonnull IWorldLocation location) {
+			NBTTagCompound entityData = stack.getTagCompound();
+			if (entityData == null || !entityData.hasKey(NBT_ENTITYID, Constants.NBT.TAG_STRING)) return null;
+			return EntityList.createEntityFromNBT(entityData, location.getWorld());
+		}
+
+		@Nonnull
+		@Override
+		protected Map<String, ?> getBasicDetails(@Nonnull ItemStack stack, @Nonnull ItemProjectileMagicNet item) {
+			return getBasicDetails(stack.getTagCompound());
+		}
+
+		@Nullable
+		@Override
+		public ItemStack getExample() {
+			Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(Const.MODID, "magic_net"));
+			if (!(item instanceof ItemProjectileMagicNet)) return null;
+
+			ItemStack stack = new ItemStack(item);
+			NBTTagCompound tag = new NBTTagCompound();
+			Entity entity = new EntitySquid(WorldDummy.INSTANCE);
+			entity.writeToNBT(tag);
+			tag.setString(NBT_ENTITYID, EntityList.getKey(entity.getClass()).toString());
+			stack.setTagCompound(tag);
+			return stack;
+		}
+	};
+
+	private IntegrationCyclic() {
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/extrautilities/IntegrationExtraUtilities.java
+++ b/src/main/java/org/squiddev/plethora/integration/extrautilities/IntegrationExtraUtilities.java
@@ -1,0 +1,55 @@
+package org.squiddev.plethora.integration.extrautilities;
+
+import com.rwtema.extrautils2.ExtraUtils2;
+import com.rwtema.extrautils2.items.ItemGoldenLasso;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.passive.EntitySquid;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.Constants;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.integration.ItemEntityStorageMetaProvider;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+
+import static com.rwtema.extrautils2.items.ItemGoldenLasso.NBT_ANIMAL;
+
+@Injects(ExtraUtils2.MODID)
+public final class IntegrationExtraUtilities {
+	public static final IMetaProvider<ItemStack> META_MONSTER_NET = new ItemEntityStorageMetaProvider<ItemGoldenLasso>(
+		"capturedEntity", ItemGoldenLasso.class,
+		"Provides the entity captured inside this lasso."
+	) {
+		@Nullable
+		@Override
+		protected Entity spawn(@Nonnull ItemStack stack, @Nonnull ItemGoldenLasso item, @Nonnull IWorldLocation location) {
+			NBTTagCompound tag = stack.getTagCompound();
+			if (tag == null || !tag.hasKey(NBT_ANIMAL, Constants.NBT.TAG_COMPOUND)) return null;
+
+			NBTTagCompound entityData = tag.getCompoundTag(NBT_ANIMAL);
+			if (!entityData.hasKey("id", Constants.NBT.TAG_STRING)) return null;
+
+			return EntityList.createEntityFromNBT(entityData, location.getWorld());
+		}
+
+		@Nonnull
+		@Override
+		protected Map<String, ?> getBasicDetails(@Nonnull ItemStack stack, @Nonnull ItemGoldenLasso item) {
+			return getBasicDetails(stack.getTagCompound());
+		}
+
+		@Nonnull
+		@Override
+		public ItemStack getExample() {
+			return ItemGoldenLasso.newCraftingStack(EntitySquid.class);
+		}
+	};
+
+	private IntegrationExtraUtilities() {
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/industrialforegoing/IntegrationIF.java
+++ b/src/main/java/org/squiddev/plethora/integration/industrialforegoing/IntegrationIF.java
@@ -1,0 +1,59 @@
+package org.squiddev.plethora.integration.industrialforegoing;
+
+import com.buuz135.industrial.item.MobImprisonmentToolItem;
+import com.buuz135.industrial.proxy.ItemRegistry;
+import com.buuz135.industrial.utils.Reference;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityList;
+import net.minecraft.entity.passive.EntitySquid;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.integration.ItemEntityStorageMetaProvider;
+import org.squiddev.plethora.utils.WorldDummy;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+
+@Injects(Reference.MOD_ID)
+public final class IntegrationIF {
+	public static final IMetaProvider<ItemStack> META_MOB_IMPRISONMENT = new ItemEntityStorageMetaProvider<MobImprisonmentToolItem>(
+		"capturedEntity", MobImprisonmentToolItem.class,
+		"Provides the entity captured inside this mob imprisonment tool."
+	) {
+		@Nullable
+		@Override
+		protected Entity spawn(@Nonnull ItemStack stack, @Nonnull MobImprisonmentToolItem item, @Nonnull IWorldLocation location) {
+			return item.containsEntity(stack) ? item.getEntityFromStack(stack, location.getWorld(), true) : null;
+		}
+
+		@Nonnull
+		@Override
+		protected Map<String, ?> getBasicDetails(@Nonnull ItemStack stack, @Nonnull MobImprisonmentToolItem item) {
+			return item.containsEntity(stack)
+				? getBasicDetails(new ResourceLocation(item.getID(stack)), stack.getTagCompound())
+				: Collections.emptyMap();
+		}
+
+		@Nonnull
+		@Override
+		public ItemStack getExample() {
+			ItemStack stack = new ItemStack(ItemRegistry.mobImprisonmentToolItem);
+			Entity entity = new EntitySquid(WorldDummy.INSTANCE);
+			NBTTagCompound tag = new NBTTagCompound();
+			tag.setString("entity", EntityList.getKey(entity).toString());
+			tag.setInteger("id", EntityList.getID(entity.getClass()));
+			entity.writeToNBT(tag);
+			stack.setTagCompound(tag);
+			return stack;
+		}
+	};
+
+	private IntegrationIF() {
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/notenoughwands/IntegrationNEW.java
+++ b/src/main/java/org/squiddev/plethora/integration/notenoughwands/IntegrationNEW.java
@@ -1,0 +1,88 @@
+package org.squiddev.plethora.integration.notenoughwands;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.passive.EntitySquid;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
+import org.squiddev.plethora.api.IWorldLocation;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.meta.IMetaProvider;
+import org.squiddev.plethora.integration.ItemEntityStorageMetaProvider;
+import romelo333.notenoughwands.Items.CapturingWand;
+import romelo333.notenoughwands.ModItems;
+import romelo333.notenoughwands.NotEnoughWands;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+
+@Injects(NotEnoughWands.MODID)
+public final class IntegrationNEW {
+	public static final IMetaProvider<ItemStack> META_CAPTURING_WAND = new ItemEntityStorageMetaProvider<CapturingWand>(
+		"capturedEntity", CapturingWand.class,
+		"Provides the entity captured inside this capturing wand."
+	) {
+		@Nullable
+		@Override
+		protected Entity spawn(@Nonnull ItemStack stack, @Nonnull CapturingWand item, @Nonnull IWorldLocation location) {
+			NBTTagCompound tag = stack.getTagCompound();
+			if (tag == null || !tag.hasKey("type", Constants.NBT.TAG_STRING)) return null;
+
+			Class<? extends EntityLivingBase> type = getClass(tag.getString("type"));
+			if (type == null) return null;
+
+			EntityLivingBase entity;
+			try {
+				entity = type.getConstructor(World.class).newInstance(location.getWorld());
+			} catch (ReflectiveOperationException | RuntimeException e) {
+				return null;
+			}
+
+			entity.readEntityFromNBT(tag.getCompoundTag("mob"));
+			return entity;
+		}
+
+		@Nonnull
+		@Override
+		protected Map<String, ?> getBasicDetails(@Nonnull ItemStack stack, @Nonnull CapturingWand item) {
+			NBTTagCompound tag = stack.getTagCompound();
+			if (tag == null || !tag.hasKey("type", Constants.NBT.TAG_STRING)) return Collections.emptyMap();
+
+			Class<? extends EntityLivingBase> type = getClass(tag.getString("type"));
+			if (type == null) return Collections.emptyMap();
+
+			EntityEntry entry = EntityRegistry.getEntry(type);
+			if (entry == null) return Collections.emptyMap();
+
+			return getBasicDetails(entry.getRegistryName(), tag.getCompoundTag("mob"));
+		}
+
+		@Nullable
+		private Class<? extends EntityLivingBase> getClass(String type) {
+			try {
+				return Class.forName(type).asSubclass(EntityLivingBase.class);
+			} catch (ReflectiveOperationException ignored) {
+				return null;
+			}
+		}
+
+		@Nonnull
+		@Override
+		public ItemStack getExample() {
+			ItemStack stack = new ItemStack(ModItems.capturingWand);
+			NBTTagCompound tag = new NBTTagCompound();
+			tag.setString("type", EntitySquid.class.getName());
+			stack.setTagCompound(tag);
+			return stack;
+		}
+	};
+
+	private IntegrationNEW() {
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/DisableAI.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/DisableAI.java
@@ -1,8 +1,6 @@
 package org.squiddev.plethora.integration.vanilla;
 
-import com.google.common.collect.Lists;
 import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.ai.EntityAIAttackMelee;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityAITasks;
 import net.minecraft.entity.ai.EntityLookHelper;
@@ -20,7 +18,6 @@ import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import org.squiddev.plethora.gameplay.Plethora;
 
 import javax.annotation.Nonnull;
-import java.util.List;
 import java.util.Optional;
 
 public final class DisableAI {

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/DisableAI.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/DisableAI.java
@@ -45,15 +45,14 @@ public final class DisableAI {
 
 	/**
 	 * Check if this entity should have its AI disabled and if so, ensure that our obedience AI is inserted.
-	 * @param entity
+	 * @param entity The entity to check
 	 */
 	public static void maybePossess(EntityLiving entity) {
 		IDisableAIHandler disableAI = entity.getCapability(DISABLE_AI_CAPABILITY, null);
 		if (disableAI != null && disableAI.isDisabled()) {
 			// Check that our obedience AI task is added.
 			// We don't remove this AI as it watches the Disable AI Capability for changes.
-			Optional<EntityAITasks.EntityAITaskEntry> obedient = entity.tasks.taskEntries.stream().filter(it -> it.action instanceof AIPlethoraObedience).findFirst();
-			if (!obedient.isPresent()) {
+			if (entity.tasks.taskEntries.stream().noneMatch(it -> it.action instanceof AIPlethoraObedience)) {
 				entity.tasks.addTask(Integer.MIN_VALUE, new AIPlethoraObedience(entity));
 			}
 		}

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/IntegrationVanilla.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/IntegrationVanilla.java
@@ -91,7 +91,7 @@ public final class IntegrationVanilla {
 	public static void entityTick(LivingEvent.LivingUpdateEvent event) {
 		EntityLivingBase livingBase = event.getEntityLiving();
 		if (livingBase instanceof EntityLiving) {
-			DisableAI.maybeClear((EntityLiving) livingBase);
+			DisableAI.maybePossess((EntityLiving) livingBase);
 		}
 	}
 

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsInventoryWorld.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsInventoryWorld.java
@@ -6,7 +6,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EntitySelectors;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
@@ -83,12 +82,7 @@ public final class MethodsInventoryWorld {
 		if (slot != -1) assertBetween(slot, 1, handler.getSlots(), "Slot out of range (%s)");
 
 		World world = location.getWorld();
-		BlockPos pos = location.getPos();
-
-		AxisAlignedBB box = new AxisAlignedBB(
-			pos.getX() + 0.5 - SUCK_RADIUS, pos.getY() + 0.5 - SUCK_RADIUS, pos.getZ() + 0.5 - SUCK_RADIUS,
-			pos.getX() + 0.5 + SUCK_RADIUS, pos.getY() + 0.5 + SUCK_RADIUS, pos.getZ() + 0.5 + SUCK_RADIUS
-		);
+		AxisAlignedBB box = location.getBounds().grow(SUCK_RADIUS, SUCK_RADIUS, SUCK_RADIUS);
 
 		int total = 0;
 		int remaining = limit;

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKinetic.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKinetic.java
@@ -52,7 +52,6 @@ public final class MethodsKinetic {
 
 	@PlethoraMethod(
 		module = PlethoraModules.KINETIC_S,
-		doc = "-- Disable the AI of this entity. Be warned: this permanently scars them - they'll never be the same again!"
 		doc = "-- Disable the AI of this entity. Their neural pathways will be inhibited preventing them thinking for themselves"
 	)
 	public static void disableAI(@FromSubtarget(ContextKeys.ORIGIN) EntityLiving entity) throws LuaException {
@@ -61,6 +60,18 @@ public final class MethodsKinetic {
 
 		disable.setDisabled(true);
 		DisableAI.maybePossess(entity);
+	}
+
+	@PlethoraMethod(
+		module = PlethoraModules.KINETIC_S,
+		doc = "-- Enable the AI of this entity."
+	)
+	public static void enableAI(@FromSubtarget(ContextKeys.ORIGIN) EntityLiving entity) throws LuaException {
+		DisableAI.IDisableAIHandler disable = entity.getCapability(DisableAI.DISABLE_AI_CAPABILITY, null);
+		if (disable == null) throw new LuaException("Cannot enable AI");
+
+		disable.setDisabled(false);
+		// We don't need to call maybePossess, because if our AI task isn't registered its irrelevant.
 	}
 
 	public static final SubtargetedModuleMethod<EntityLiving> WALK = SubtargetedModuleMethod.of(

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKinetic.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKinetic.java
@@ -53,13 +53,14 @@ public final class MethodsKinetic {
 	@PlethoraMethod(
 		module = PlethoraModules.KINETIC_S,
 		doc = "-- Disable the AI of this entity. Be warned: this permanently scars them - they'll never be the same again!"
+		doc = "-- Disable the AI of this entity. Their neural pathways will be inhibited preventing them thinking for themselves"
 	)
 	public static void disableAI(@FromSubtarget(ContextKeys.ORIGIN) EntityLiving entity) throws LuaException {
 		DisableAI.IDisableAIHandler disable = entity.getCapability(DisableAI.DISABLE_AI_CAPABILITY, null);
 		if (disable == null) throw new LuaException("Cannot disable AI");
 
 		disable.setDisabled(true);
-		DisableAI.maybeClear(entity);
+		DisableAI.maybePossess(entity);
 	}
 
 	public static final SubtargetedModuleMethod<EntityLiving> WALK = SubtargetedModuleMethod.of(

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKineticEntity.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKineticEntity.java
@@ -54,8 +54,7 @@ public final class MethodsKineticEntity {
 		yaw %= 360;
 		pitch %= 360;
 
-		// Clamp pitch between -90 and 90 degrees for aesthetics.
-		pitch = pitch > 90 ? 90 : pitch < -90 ? -90 : pitch;
+		pitch = MathHelper.clamp(pitch, -90, 90);
 
 		if (target instanceof EntityPlayerMP) {
 			NetHandlerPlayServer handler = ((EntityPlayerMP) target).connection;

--- a/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKineticEntity.java
+++ b/src/main/java/org/squiddev/plethora/integration/vanilla/method/MethodsKineticEntity.java
@@ -54,6 +54,9 @@ public final class MethodsKineticEntity {
 		yaw %= 360;
 		pitch %= 360;
 
+		// Clamp pitch between -90 and 90 degrees for aesthetics.
+		pitch = pitch > 90 ? 90 : pitch < -90 ? -90 : pitch;
+
 		if (target instanceof EntityPlayerMP) {
 			NetHandlerPlayServer handler = ((EntityPlayerMP) target).connection;
 			handler.setPlayerLocation(target.posX, target.posY, target.posZ, (float) yaw, (float) pitch);

--- a/src/test/resources/assets/plethora-test/test-rom/spec/vanilla/inventory_spec.lua
+++ b/src/test/resources/assets/plethora-test/test-rom/spec/vanilla/inventory_spec.lua
@@ -28,7 +28,7 @@ describe("inventories", function()
 
 		it("on a stick", function()
 			local inv = setup()
-			expect(inv.getItemMeta(1)):same {
+			expect(inv.getItemMeta(1)):matches {
 				name = "minecraft:stick", displayName = "Stick", rawName = "item.stick",
 				damage = 0, maxDamage = 0, count = 50, maxCount = 64,
 				ores = { stickWood = true }


### PR DESCRIPTION
## AI Improvements

Hello, I've made some quality of life changes to the neural interface and the kinetic module.
* Mobs can now swing/use/look up and down as pitch now works [demo](https://www.youtube.com/watch?v=NxwgPrqZtKw) #215 #162 
* Mobs can have their AI reenabled `enableAI()`, disable is no longer permanent. The mob should be entirely unscared. [demo](https://www.youtube.com/watch?v=lOuw9qRiLCU) #19
* ~Tall mobs that have an eye height above a meter can now look down >= 45 degrees and pick up items from their feet with `suck()`. [demo](https://www.youtube.com/watch?v=tILhAy2n8B4)~

Let me know if you'd like me to squash these commits or change anything about the PR here before pulling. I'd be happy to apply fixes to the branch.

Josh.