### PR TITLE
Set correct output stackSize for Module Level Recipe.

### DIFF
--- a/src/main/java/org/squiddev/plethora/gameplay/modules/ModuleLevelRecipe.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/ModuleLevelRecipe.java
@@ -36,6 +36,7 @@ public final class ModuleLevelRecipe extends ShapelessRecipes {
 			if (stack.getItem() != output.getItem() || stack.getItemDamage() != output.getItemDamage()) continue;
 
 			ItemStack result = stack.copy();
+			result.setCount(1);
 			NBTTagCompound tag = result.getTagCompound();
 			if (tag == null) result.setTagCompound(tag = new NBTTagCompound());
 			tag.setInteger("level", tag.hasKey("level", Constants.NBT.TAG_ANY_NUMERIC) ? tag.getInteger("level") + 1 : 1);


### PR DESCRIPTION
As seen in example below when increasing level of module the crafting output stack has stackSize equal to stack in input causing item duplication bug.

![2019-12-19_23-52-25](https://user-images.githubusercontent.com/5893536/71218077-7cbc4580-22c0-11ea-975e-59c804dfcdae.gif)

Fixed by setting stackSize to one on copy.

![2019-12-20_00-30-12](https://user-images.githubusercontent.com/5893536/71218089-89409e00-22c0-11ea-819c-24dde4598c91.gif)

