### PR TITLE
Tweak canvas3d item auto rotation.

### DIFF
--- a/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Item3D.java
+++ b/src/main/java/org/squiddev/plethora/gameplay/modules/glasses/objects/object3d/Item3D.java
@@ -155,7 +155,7 @@ public class Item3D extends BaseObject implements Scalable, Positionable3D, Dept
 		if (rotation == null) {
 			RenderManager renderManager = mc.getRenderManager();
 			GlStateManager.rotate(180 - renderManager.playerViewY, 0, 1, 0);
-			GlStateManager.rotate(renderManager.playerViewX, 1, 0, 0);
+			GlStateManager.rotate(-renderManager.playerViewX, 1, 0, 0);
 		} else {
 			GlStateManager.rotate((float) rotation.x, 1, 0, 0);
 			GlStateManager.rotate((float) rotation.y, 0, 1, 0);


### PR DESCRIPTION
I noticed that  canvas3d items when set to face player rotation don't actually face player on vertical axis:
https://gfycat.com/ThornyWillingAlpaca

This edit fixes the issue:
https://gfycat.com/ShabbyFaroffCarpenterant
