### PR TITLE
Add Basic Buildcraft support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ dependencies {
 	integrationMod "cyclic:Cyclic:1.12.2:1.19.9"
 	integrationMod "extra-utilities:extrautils2:1.12:1.9.9"
 	integrationMod "not-enough-wands:notenoughwands:1.12:1.8.1"
+	integrationMod "buildcraft:buildcraft:all:7.99.24.4"
 
 	compileOnly('org.squiddev:ConfigGen:1.2.5') { exclude group: 'net.minecraftforge' }
 

--- a/src/main/java/org/squiddev/plethora/integration/buildcraft/TileControllable.java
+++ b/src/main/java/org/squiddev/plethora/integration/buildcraft/TileControllable.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Injects(BCCore.MODID)
 public final class TileControllable {
 
 	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get a list of all supported control modes.")
@@ -25,27 +24,12 @@ public final class TileControllable {
 	}
 
 	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Reports true if the Block accept the given mode.")
-	public static boolean acceptsControlMode(@FromTarget IControllable controllable, String modeName) throws LuaException {
-		IControllable.Mode mode;
-		try {
-			mode = IControllable.Mode.valueOf(modeName.toUpperCase());
-		} catch (IllegalArgumentException e) {
-			throw new LuaException("No such control mode");
-		}
-
-
+	public static boolean acceptsControlMode(@FromTarget IControllable controllable, IControllable.Mode mode) throws LuaException {
 		return controllable.acceptsControlMode(mode);
 	}
 
 	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Set the Control mode of the block to the given mode.")
-	public static void setControlMode(@FromTarget IControllable controllable, String modeName) throws LuaException {
-		IControllable.Mode mode;
-		try {
-			mode = IControllable.Mode.valueOf(modeName.toUpperCase());
-		} catch (IllegalArgumentException e) {
-			throw new LuaException("No such control mode");
-		}
-
+	public static void setControlMode(@FromTarget IControllable controllable, IControllable.Mode mode) throws LuaException {
 		if (controllable.acceptsControlMode(mode)) {
 			controllable.setControlMode(mode);
 		}

--- a/src/main/java/org/squiddev/plethora/integration/buildcraft/TileControllable.java
+++ b/src/main/java/org/squiddev/plethora/integration/buildcraft/TileControllable.java
@@ -1,0 +1,53 @@
+package org.squiddev.plethora.integration.buildcraft;
+
+import buildcraft.api.tiles.IControllable;
+import buildcraft.core.BCCore;
+import dan200.computercraft.api.lua.LuaException;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.method.wrapper.FromTarget;
+import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Injects(BCCore.MODID)
+public final class TileControllable {
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get a list of all supported control modes.")
+	public static List<String> getSupportedControlModes(@FromTarget IControllable controllable) {
+		return Arrays.stream(IControllable.Mode.VALUES).filter(controllable::acceptsControlMode).map(mode -> mode.lowerCaseName).collect(Collectors.toList());
+	}
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get the control mode.")
+	public static String getControlMode(@FromTarget IControllable controllable) {
+		return controllable.getControlMode().lowerCaseName;
+	}
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Reports true if the Block accept the given mode.")
+	public static boolean acceptsControlMode(@FromTarget IControllable controllable, String modeName) throws LuaException {
+		IControllable.Mode mode;
+		try {
+			mode = IControllable.Mode.valueOf(modeName.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new LuaException("No such control mode");
+		}
+
+
+		return controllable.acceptsControlMode(mode);
+	}
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Set the Control mode of the block to the given mode.")
+	public static void setControlMode(@FromTarget IControllable controllable, String modeName) throws LuaException {
+		IControllable.Mode mode;
+		try {
+			mode = IControllable.Mode.valueOf(modeName.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new LuaException("No such control mode");
+		}
+
+		if (controllable.acceptsControlMode(mode)) {
+			controllable.setControlMode(mode);
+		}
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHasWork.java
+++ b/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHasWork.java
@@ -6,7 +6,6 @@ import org.squiddev.plethora.api.Injects;
 import org.squiddev.plethora.api.method.wrapper.FromTarget;
 import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
 
-@Injects(BCCore.MODID)
 public final class TileHasWork {
 
 	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Reports true if the Block has work to do.")

--- a/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHasWork.java
+++ b/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHasWork.java
@@ -1,0 +1,16 @@
+package org.squiddev.plethora.integration.buildcraft;
+
+import buildcraft.api.tiles.IHasWork;
+import buildcraft.core.BCCore;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.method.wrapper.FromTarget;
+import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
+
+@Injects(BCCore.MODID)
+public final class TileHasWork {
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Reports true if the Block has work to do.")
+	public static boolean hasWork(@FromTarget IHasWork hasWork) {
+		return hasWork.hasWork();
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHeatable.java
+++ b/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHeatable.java
@@ -1,0 +1,31 @@
+package org.squiddev.plethora.integration.buildcraft;
+
+import buildcraft.api.tiles.IHeatable;
+import buildcraft.core.BCCore;
+import org.squiddev.plethora.api.Injects;
+import org.squiddev.plethora.api.method.wrapper.FromTarget;
+import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
+
+@Injects(BCCore.MODID)
+public final class TileHeatable {
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get the minimal heat.")
+	public static double getMinHeat(@FromTarget IHeatable heatable) {
+		return heatable.getMinHeatValue();
+	}
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get the maximal heat.")
+	public static double getMaxHeat(@FromTarget IHeatable heatable) {
+		return heatable.getMaxHeatValue();
+	}
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get the current heat.")
+	public static double getCurrentHeat(@FromTarget IHeatable heatable) {
+		return heatable.getCurrentHeatValue();
+	}
+
+	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get the ideal heat.")
+	public static double getIdealHeat(@FromTarget IHeatable heatable) {
+		return heatable.getIdealHeatValue();
+	}
+}

--- a/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHeatable.java
+++ b/src/main/java/org/squiddev/plethora/integration/buildcraft/TileHeatable.java
@@ -6,7 +6,6 @@ import org.squiddev.plethora.api.Injects;
 import org.squiddev.plethora.api.method.wrapper.FromTarget;
 import org.squiddev.plethora.api.method.wrapper.PlethoraMethod;
 
-@Injects(BCCore.MODID)
 public final class TileHeatable {
 
 	@PlethoraMethod(modId = BCCore.MODID, doc = "-- Get the minimal heat.")


### PR DESCRIPTION
This PR adds support for all interactions that can be done with Gates in Buildcraft. Sadly not all Blocks implement the needed Interfaces or I just didnt saw it. 